### PR TITLE
V1.6.1版本

### DIFF
--- a/.idea/encodings.xml
+++ b/.idea/encodings.xml
@@ -29,6 +29,8 @@
     <file url="file://$PROJECT_DIR$/xiaou-moyu/src/main/resources" charset="UTF-8" />
     <file url="file://$PROJECT_DIR$/xiaou-notification/src/main/java" charset="UTF-8" />
     <file url="file://$PROJECT_DIR$/xiaou-notification/src/main/resources" charset="UTF-8" />
+    <file url="file://$PROJECT_DIR$/xiaou-plan/src/main/java" charset="UTF-8" />
+    <file url="file://$PROJECT_DIR$/xiaou-plan/src/main/resources" charset="UTF-8" />
     <file url="file://$PROJECT_DIR$/xiaou-points/src/main/java" charset="UTF-8" />
     <file url="file://$PROJECT_DIR$/xiaou-points/src/main/resources" charset="UTF-8" />
     <file url="file://$PROJECT_DIR$/xiaou-resume/src/main/java" charset="UTF-8" />

--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
-﻿# Code Nest 
-
+# Code Nest
 
 ![Version](https://img.shields.io/badge/version-1.6.0-blue.svg)
 ![Java](https://img.shields.io/badge/java-17-orange.svg)
@@ -7,121 +6,116 @@
 ![Vue](https://img.shields.io/badge/vue-3.x-4fc08d.svg)
 ![License](https://img.shields.io/badge/license-MIT-green.svg)
 
-
-
 ## 📖 项目简介
 
-Code Nest 是一个基于 Spring Boot + Vue3 的前后端分离的一个程序员社区系统。
+Code Nest 是一个面向开发者的成长型社区与知识运营平台，采用 Spring Boot 3.4.4 + Vue3 + Vite 的前后端分离架构，后台整合 Sa-Token 权限、Redisson 缓存、MySQL 题库/内容系统以及 Prometheus 监控指标，提供包含题库、面试辅导、知识图谱、博客、代码工坊、在线简历、IM 聊天、积分激励与抽奖等在内的多模块能力。
 
-### ✨ 主要特性
+### 平台定位
 
-- 🔐 **完善的权限管理** - Sa-Token认证系统，支持管理员和普通用户双重权限体系
-- 📚 **丰富的题库功能** - 支持题目分类、题单管理、随机抽题、收藏功能
-- 🎯 **智能抽题系统** - 可选择多个题单进行随机抽题，支持自定义抽题数量
-- 💫 **现代化UI** - 基于Element Plus的美观界面，支持响应式设计
-- 📊 **系统监控** - SQL监控、操作日志、登录日志等完整的监控体系
-- 🚀 **高性能架构** - Redis缓存、数据库连接池、异步处理等性能优化
+- **vue3-admin-front**：面向运营/管理员的后台，覆盖菜单/角色、内容审核、题库管理、版本追踪、任务配置、观测看板等能力。
+- **vue3-user-front**：面向开发者的用户端，提供刷题、简历制作、动态广场、博客阅读、代码分享、通知消息等场景。
+- **xiaou-application**：多模块聚合的 Spring Boot API，整合 `xiaou-*` 业务模块，对外暴露统一的 `/api` 网关、鉴权、日志与监控。
+
+## ✨ 功能亮点
+
+### 平台级能力
+
+- **细粒度鉴权**：基于 Sa-Token 构建双端（管理员/用户）登录域、权限树、会话隔离与 Token 签名机制，支持并发登录及多场景鉴权。
+- **智能题库体系**：`xiaou-interview` 内置题型分类、刷题记录、自动组卷、错题重练及统计报表，配合知识图谱实现学习闭环。
+- **内容创作矩阵**：博客系统、动态广场、Bug 趣味墙、代码工坊与在线简历模块组合为全栈内容生产链路。
+- **成长激励与运营**：积分体系、摸鱼任务、抽奖活动、版本发布墙、消息通知与活动打卡全面强化用户粘性。
+- **统一资产管理**：`xiaou-filestorage` 负责文件/附件/导出作品上传，多种存储适配；`xiaou-resume` 支持简历模板、模块化数据、版本历史与多格式导出。
+- **企业级可观测性**：SQL/行为审计、Redisson 限流、异步任务监控、Prometheus + Grafana 指标、Nginx/ Docker 部署脚本开箱即用。
+
+### 模块亮点
+
+- **在线简历（xiaou-resume）**：拖拽式编辑、模板市场、版本比对、PDF/Word/HTML 导出与分享统计。
+- **代码工坊（xiaou-codepen）**：内置前端 + 后端 + SQL 演示沙盒，支持作品发布、Fork、收藏及后台运营。
+- **知识图谱（xiaou-knowledge）**：以节点关系呈现技术体系，结合 Pinia/G6 构建交互式知识网络。
+- **动态/社区（xiaou-moment、xiaou-community）**：用户动态流、话题标签、点赞/收藏、内容推荐权重与违规审核。
+- **通知 & IM（xiaou-notification、xiaou-chat）**：系统/私信/群聊，WebSocket 实时消息、撤回、封禁、敏感词检测。
+- **敏感词/风控（xiaou-sensitive、xiaou-sensitive-api）**：分词匹配、命中日志、策略管理、WebHook 回调。
+- **版本与运营（xiaou-version、xiaou-moyu、xiaou-points、lottery）**：版本里程碑、摸鱼打卡、积分规则、抽奖活动与奖品管理。
+
+### 运维与安全
+
+- SQL 慢查询与操作审计、行为日志沉淀到 `xiaou.monitor`，支持异步写入与保留周期配置。
+- `docs/Prometheus运维部署指南.md` 提供 Prometheus + Grafana 一键部署说明，Actuator/Micrometer 暴露业务指标。
+- Dockerfile、Nginx 反向代理配置与多环境配置文件（dev/prod）一应俱全，便于快速上线。
 
 ## 🏗️ 技术架构
 
 ### 后端技术栈
 
-- **框架**: Spring Boot 3.4.4
-- **安全**: Sa-Token权限认证框架
-- **数据库**: MySQL 8.0 + MyBatis
-- **缓存**: Redis (Redisson)
-- **文档**: SpringDoc (OpenAPI 3.0)
-- **工具**: Hutool、Lombok
-- **监控**: 自研SQL监控系统
+- Spring Boot 3.4.4、Spring MVC、Spring Validation、Sa-Token 鉴权。
+- MySQL 8 + MyBatis（含 PageHelper）、多数据源、数据库脚本在 `sql/`。
+- Redis 6 + Redisson（分布式锁、延迟队列），异步任务/定时调度。
+- SpringDoc OpenAPI 3、Knife4j、Hutool、Lombok、MapStruct 等辅助库。
+- 日志监控：Micrometer、Prometheus Exporter、SQL/操作日志框架、自定义监控配置。
 
 ### 前端技术栈
 
-- **框架**: Vue 3 + Composition API
-- **构建工具**: Vite
-- **UI组件**: Element Plus
-- **状态管理**: Pinia
-- **路由**: Vue Router 4
-- **HTTP客户端**: Axios
-- **样式**: SCSS
+- Vue 3 + Composition API + TypeScript（可选），构建工具 Vite 5。
+- Element Plus 组件库、Pinia 状态、Vue Router 4、Axios 网络层、SCSS/Sass。
+- 可视化：ECharts、D3、@antv/g6、markdown-it、highlight.js、nprogress。
+- 代码规范：ESLint + eslint-plugin-vue + Prettier（可选），统一 `.editorconfig`。
 
-### 系统架构
+### 基础设施
 
-```
-┌─────────────────┐    ┌─────────────────┐
-│   管理员端       │    │     用户端       │
-│  (vue3-admin)   │    │  (vue3-user)    │
-└─────┬───────────┘    └─────┬───────────┘
-      │                      │
-      └──────────┬───────────┘
-                 │
-    ┌────────────▼─────────────┐
-    │      Nginx (可选)        │
-    └────────────┬─────────────┘
-                 │
-    ┌────────────▼─────────────┐
-    │     Spring Boot API      │
-    │    ┌─────────────────┐   │
-    │    │   xiaou-system    │   │
-    │    │   xiaou-user      │   │
-    │    │ xiaou-interview   │   │
-    │    │  xiaou-monitor    │   │
-    │    │  xiaou-moment     │   │
-    │    │ xiaou-notification│   │
-    │    │ xiaou-filestorage │   │
-    │    │  xiaou-knowledge  │   │
-    │    │   xiaou-version   │   │
-    │    │    xiaou-moyu     │   │
-    │    │    xiaou-points   │   │
-    │    │     xiaou-chat    │   │
-    │    │  xiaou-common     │   │
-    │    └─────────────────┘   │
-    └────────────┬─────────────┘
-                 │
-    ┌────────────▼─────────────┐
-    │      MySQL + Redis       │
-    └──────────────────────────┘
-```
+- MySQL、Redis、对象存储（本地/Tencent COS 等）、Nginx、Docker、GitHub Actions（可扩展）。
+- Prometheus + Grafana + Alertmanager、日志采集（logs/）、监控告警配置。
 
-## 📦 项目结构
+## 📦 模块一览
+
+| 模块 | 说明 | 关键功能 |
+| --- | --- | --- |
+| xiaou-application | 主 API 工程 | 聚合所有业务模块、统一配置、网关、鉴权与监控出口 |
+| xiaou-common | 通用基础库 | 自定义注解、AOP、统一返回体、异常、工具集 |
+| xiaou-system | 系统管理 | 组织、角色、菜单、字典、参数、审计日志 |
+| xiaou-user / xiaou-user-api | 用户中心 | 用户注册、认证、资料、登录态 API 隔离 |
+| xiaou-interview | 面试题库 | 题目、试卷、刷题记录、统计、推荐 |
+| xiaou-community | 社区/岗位 | 帖子、岗位、任务调度、运营后台 |
+| xiaou-moment | 动态广场 | 动态发布、点赞、收藏、推荐算法、审核 |
+| xiaou-blog | 博客 | Markdown 编辑、标签、归档、评论 |
+| xiaou-codepen | 代码工坊 | 代码模板、在线运行、作品管理、Fork/收藏 |
+| xiaou-resume | 在线简历 | 模板库、模块化填写、版本历史、多格式导出 |
+| xiaou-filestorage | 文件存储 | 本地/云存储、上传、分片、权限与统计 |
+| xiaou-notification | 消息中心 | 系统通知、私信、消息状态、推送 |
+| xiaou-chat | IM 聊天 | WebSocket 实时通信、撤回、禁言、房间 |
+| xiaou-sensitive / xiaou-sensitive-api | 敏感词 | 词库维护、命中记录、外部 API |
+| xiaou-knowledge | 知识图谱 | 节点管理、图谱渲染、知识库 |
+| xiaou-version | 版本档案 | 版本时间线、发布记录、变更说明 |
+| xiaou-moyu | 摸鱼面板 | 日常任务、健康打卡、工作台 |
+| xiaou-points | 积分体系 | 积分规则、账户、排行榜、明细 |
+| xiaou-monitor | SQL/监控 | SQL 采集、慢查询、日志审计、观测面板 |
+
+### 前端应用
+
+| 模块 | 说明 | 启动命令 |
+| --- | --- | --- |
+| vue3-admin-front | 管理后台，Element Plus + Pinia | `npm install && npm run dev`（端口 5173） |
+| vue3-user-front | 用户端，组件与依赖同后台 | `npm install && npm run dev`（端口 5174） |
+
+## 🗂️ 目录结构
 
 ```
 Code-Nest/
-├── docs/                           # 文档目录
-├── sql/                           # 数据库脚本
-│   ├── struct.sql                 # 表结构
-│   └── data.sql                   # 初始数据
-├── vue3-admin-front/              # 管理员前端
-├── vue3-user-front/               # 用户端前端
-├── xiaou-application/             # 启动模块
-├── xiaou-common/                  # 公共模块
-│   ├── annotation/                # 自定义注解
-│   ├── aspect/                    # 切面处理
-│   ├── config/                    # 配置类
-│   ├── core/                      # 核心类
-│   ├── enums/                     # 枚举类
-│   ├── exception/                 # 异常处理
-│   ├── security/                  # 安全相关
-│   └── utils/                     # 工具类
-├── xiaou-interview/               # 面试题模块
-│   ├── controller/                # 控制器
-│   │   ├── admin/                 # 管理员接口
-│   │   └── pub/                   # 公开接口
-│   ├── domain/                    # 实体类
-│   ├── dto/                       # 数据传输对象
-│   ├── mapper/                    # 数据映射
-│   └── service/                   # 业务逻辑
-├── xiaou-monitor/                 # 监控模块
-├── xiaou-system/                  # 系统模块
-├── xiaou-user/                    # 用户模块
-├── xiaou-moment/                  # 朋友圈模块
-├── xiaou-notification/            # 消息通知模块
-├── xiaou-filestorage/             # 文件存储模块
-├── xiaou-knowledge/               # 知识图谱模块
-├── xiaou-version/                 # 版本管理模块
-├── xiaou-moyu/                    # 摸鱼工具模块
-├── xiaou-points/                  # 积分系统模块
-├── xiaou-chat/                    # IM聊天室模块
-└── pom.xml                        # Maven主配置
+├── docker/                     # 后端 Dockerfile、compose 示例
+├── docs/
+│   ├── PRD/                    # 各业务模块 PRD/需求文档
+│   └── Prometheus运维部署指南.md
+├── logs/                       # 运行期日志（开发环境可忽略）
+├── sql/
+│   ├── struct.sql              # 数据库结构
+│   ├── data.sql                # 初始化数据
+│   └── v1.6.0/                 # 增量脚本（CodePen 等）
+├── vue3-admin-front/           # 管理端前端
+├── vue3-user-front/            # 用户端前端
+├── xiaou-common/               # 通用模块
+├── xiaou-application/          # Spring Boot 聚合工程（启动入口）
+├── xiaou-*/                    # 业务子模块（interview、blog、resume…）
+├── pom.xml                     # 多模块 Maven 配置
+└── README.md
 ```
 
 ## 🚀 Quick Start
@@ -129,10 +123,11 @@ Code-Nest/
 ### 环境要求
 
 - Java 17+
-- Node.js 16+
+- Node.js 18+（Vite 5 推荐）
+- Maven 3.8+
 - MySQL 8.0+
 - Redis 6.0+
-- Maven 3.8+
+- 可选：Docker、Nginx、Prometheus/Grafana
 
 ### 1. 克隆项目
 
@@ -141,27 +136,28 @@ git clone https://github.com/your-username/Code-Nest.git
 cd Code-Nest
 ```
 
-### 2. 数据库初始化
+### 2. 初始化数据库
 
 ```bash
-# 创建数据库
 mysql -u root -p
+
 CREATE DATABASE code_nest DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
-
-# 导入表结构和数据
-
+USE code_nest;
+SOURCE sql/struct.sql;
+SOURCE sql/data.sql;
+-- 如需最新功能，请额外执行 sql/v1.6.0/*.sql
 ```
 
 ### 3. 配置文件
 
-修改 `xiaou-application/src/main/resources/application-dev.yml`:
+编辑 `xiaou-application/src/main/resources/application-dev.yml`（或新建 `application-local.yml`）：
 
 ```yaml
 spring:
   datasource:
-    url: jdbc:mysql://localhost:3306/code_nest?serverTimezone=Asia/Shanghai&useUnicode=true&characterEncoding=utf-8
-    username: your_username
-    password: your_password
+    url: jdbc:mysql://localhost:3306/code_nest?useUnicode=true&characterEncoding=utf-8&serverTimezone=Asia/Shanghai
+    username: your_mysql_user
+    password: your_mysql_password
   data:
     redis:
       redisson:
@@ -169,29 +165,42 @@ spring:
           singleServerConfig:
             address: "redis://127.0.0.1:6379"
             database: 3
+
+sa-token:
+  token-name: Authorization
+  token-prefix: Bearer
+  timeout: 604800
+  activity-timeout: 1800
+
+xiaou:
+  monitor:
+    enabled: true
+    slow-sql-threshold: 1000
+    async-save: true
+    retention-days: 30
 ```
+
+按需补充短信/OSS/COS 等密钥。
 
 ### 4. 启动后端
 
 ```bash
-# 编译项目
+# 一键编译
 mvn clean package -DskipTests
 
-# 启动服务
-cd xiaou-application
-mvn spring-boot:run
+# 开发模式启动（默认使用 dev 配置）
+mvn -pl xiaou-application -am spring-boot:run
 
-# 或者运行jar包
-java -jar target/xiaou-application-1.6.0.jar
+# 或直接运行打包后的 jar
+java -jar xiaou-application/target/xiaou-application-1.6.0.jar --spring.profiles.active=prod
 ```
 
-服务启动后访问: http://localhost:9999/api
-
-API文档: http://localhost:9999/api/swagger-ui.html
+- API 根地址：`http://localhost:9999/api`
+- Swagger / Knife4j：`http://localhost:9999/api/swagger-ui.html`
 
 ### 5. 启动前端
 
-#### 管理员端
+#### 管理后台
 
 ```bash
 cd vue3-admin-front
@@ -199,9 +208,7 @@ npm install
 npm run dev
 ```
 
-访问: http://localhost:5173
-
-默认管理员账号: `admin` / `123456`
+访问 `http://localhost:5173`
 
 #### 用户端
 
@@ -211,43 +218,46 @@ npm install
 npm run dev
 ```
 
-访问: http://localhost:5174
+访问 `http://localhost:5174`
 
-可注册新用户或使用测试账号
+### 6. 常用账号
 
-### 6. 构建部署
+| 端 | 账号 | 密码 | 备注 |
+| --- | --- | --- | --- |
+| 管理后台 | `admin` | `123456` | 可在用户管理中修改 |
+| 用户端 | 已内置演示数据 | `sql/data.sql` 中提供 | 也可自行注册 |
+
+### 7. 构建与部署产物
 
 ```bash
-# 后端打包
+# 后端
 mvn clean package -DskipTests
 
-# 前端打包
+# 前端
 cd vue3-admin-front && npm run build
 cd vue3-user-front && npm run build
 ```
 
-## 🔧 配置说明
+静态资源输出至 `dist/`，可由 Nginx 或对象存储托管。
 
-### Sa-Token配置
+## 🔧 配置与运维
+
+### Sa-Token 关键配置
 
 ```yaml
 sa-token:
   token-name: Authorization
-  timeout: 604800           # Token有效期 7天 (秒)
-  activity-timeout: 1800    # Token临时有效期 30分钟 (秒)
-  is-concurrent: true       # 允许同一账号并发登录
-  is-share: false          # 每次登录新建Token
-  token-style: uuid        # Token风格
-  token-prefix: Bearer     # Token前缀
-  
-  # Sa-Token 独立 Redis 配置
+  token-style: uuid
+  is-share: false
+  is-concurrent: true
+  token-prefix: Bearer
   alone-redis:
     host: 127.0.0.1
     port: 6379
-    database: 4            # 使用独立database
+    database: 4
 ```
 
-### Redis配置
+### Redis / Redisson
 
 ```yaml
 spring:
@@ -258,371 +268,175 @@ spring:
           singleServerConfig:
             address: "redis://127.0.0.1:6379"
             database: 3
+            password: your_redis_password
 ```
 
-### 监控配置
+### SQL 与监控
 
 ```yaml
 xiaou:
   monitor:
-    enabled: true                    # 启用SQL监控
-    slow-sql-threshold: 1000        # 慢SQL阈值(ms)
-    async-save: true                # 异步保存日志
-    retention-days: 30              # 日志保留天数
+    enabled: true
+    slow-sql-threshold: 800
+    async-save: true
+    retention-days: 30
+management:
+  endpoints:
+    web:
+      exposure:
+        include: health,metrics,prometheus
 ```
 
-## 🚀 部署指南
+- Prometheus 抓取地址：`http://<host>:9999/api/actuator/prometheus`
+- Grafana Dashboard/报警配置参考 `docs/Prometheus运维部署指南.md`
 
-### Docker部署
+### 日志
+
+- 默认输出到 `logs/` 目录，按日期分片。
+- Sa-Token、SQL、操作日志支持异步保存，可在 `application-*.yml` 中自定义。
+
+## ☁️ 部署指南
+
+### Docker
 
 ```bash
 # 构建镜像
-docker build -t code-nest:1.6.0 .
+docker build -t code-nest:1.6.0 -f docker/Dockerfile .
 
 # 运行容器
 docker run -d \
   --name code-nest \
   -p 9999:9999 \
   -e SPRING_PROFILES_ACTIVE=prod \
+  --env-file docker/env/example.env \
   code-nest:1.6.0
 ```
 
-### Nginx配置
+可与 MySQL/Redis 容器组合，或使用 `docker-compose`.
+
+### Nginx
 
 ```nginx
 server {
     listen 80;
     server_name your-domain.com;
-    
-    # 前端静态文件
+
+    # 管理端静态资源
+    location /admin/ {
+        root /opt/code-nest/vue3-admin-front/dist;
+        try_files $uri $uri/ /admin/index.html;
+    }
+
+    # 用户端静态资源
     location / {
-        root /usr/share/nginx/html;
+        root /opt/code-nest/vue3-user-front/dist;
         try_files $uri $uri/ /index.html;
     }
-    
-    # API代理
+
+    # API 转发
     location /api/ {
-        proxy_pass http://localhost:9999/api/;
+        proxy_pass http://127.0.0.1:9999/api/;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
     }
 }
 ```
 
-## 🤝 贡献指南
+## 📚 文档与资料
 
-欢迎贡献代码！请遵循以下步骤:
+- `docs/PRD/`：覆盖简历、代码工坊、IM、积分、抽奖、知识图谱、敏感词、SQL 优化等 20+ 模块的产品文档。
+- `docs/Prometheus运维部署指南.md`：Prometheus + Grafana 安装、指标、告警策略。
+- `sql/struct.sql` & `sql/data.sql`：完整结构与示例数据，`sql/v1.6.0/` 为增量脚本。
+- `pom.xml`：多模块管理、版本统一、Flatten 插件配置。
+- `docker/`：容器化部署示例。
 
-1. Fork 项目
-2. 创建功能分支 (`git checkout -b feature/AmazingFeature`)
-3. 提交更改 (`git commit -m 'Add some AmazingFeature'`)
-4. 推送到分支 (`git push origin feature/AmazingFeature`)
-5. 创建 Pull Request
+## 📝 更新日志
 
-## 📄 更新日志
+仅列出最近版本，更多历史可查看 `git log`。
 
 ### v1.6.0 🚀
 
-#### 🆕 新增内容
-- **在线简历模块**：新增 xiaou-resume 服务，提供模板中心、简历管理、模块化内容、版本快照、分享与访问统计。
-- **代码共享中心**：CodePen 模块正式上线（前后台 + SQL），支持作品发布、Fork、收藏、评论与后台运营。
-- **监控体系升级**：接入 Prometheus + Grafana，结合 Actuator / Micrometer 指标与告警规则，替换旧 SQL 调用树监控。
-- **敏感词增强**：敏感词系统补充统计分析与配置项，管理端可视化能力同步完善。
-- **数据库脚本**：sql/v1.6.0 目录新增简历与 CodePen 建表脚本，升级一步到位。
-
-#### 🔧 优化与修复
-- 简历导出支持 PDF / Word / HTML，并与文件存储打通，自动上传至 COS 返回真实下载链接。
-- 用户端上线模板大厅、简历工作台与编辑器；管理端提供模板维护、数据总览、健康巡检页面。
-- README、导航、版本号等展示信息同步到 1.6.0，导出/分享交互体验全面升级。
+- 🆕 **在线简历模块**：`xiaou-resume` 支持模板市场、模块化数据、版本快照、拖拽编辑与 PDF/Word/HTML 导出。
+- 🆕 **代码工坊（CodePen）**：支持前端/后端/SQL 演示、作品发布、Fork/收藏/点赞、后台运营、商业化配置。
+- 🆕 **可观测中心**：Prometheus + Grafana 监控整合 Micrometer/Actuator 指标、SQL 观测、告警与文档。
+- 🆕 **刷题洞察**：题库模块新增统计面板、算法难度画像、错题同步订阅。
+- 🗄️ **数据库脚本**：`sql/v1.6.0` 目录补充 CodePen/简历相关表结构。
+- 🔧 **导出 & 存储**：简历导出自动上传至 `xiaou-filestorage`，新增 COS/MinIO 适配。
+- 🔧 **内容体验**：社区/简历模板支持用户端/后台协同维护，README 与版本说明全面升级。
 
 ### v1.5.0 🎉
 
-#### 📝 博客系统模块
-- **博客功能完整实现** - 全新的博客创作和管理系统
-  - 博客文章发布和管理
-  - Markdown编辑器支持
-  - 文章分类和标签
-  - 文章搜索和筛选
-  - 评论互动功能
-
-#### 🎲 抽奖系统模块
-- **抽奖管理功能** - 完整的抽奖活动管理
-  - 抽奖活动创建和配置
-  - 奖品设置和库存管理
-  - 中奖记录和统计
-  - 后台抽奖管理界面
-
-#### 🏷️ 社区增强功能
-- **标签管理系统** - 社区内容分类和组织
-  - 标签创建和管理
-  - 标签关联和搜索
-  - 热门标签统计
-  - 标签云展示
-
-#### ✨ 动态功能增强
-- **动态收藏和搜索** - 丰富的动态互动功能
-  - 动态收藏功能
-  - 动态搜索和筛选
-  - 用户动态列表
-  - 个人收藏列表
-  
-- **热门动态算法** - 智能推荐系统
-  - 热度分数计算（点赞×2 + 评论×3 + 浏览×0.1）
-  - 定时任务更新热门动态（每10分钟）
-  - 动态浏览统计和防重复记录
-  - 批量获取优化性能
-  
-- **动态安全机制** - 内容审核和过滤
-  - 敏感词检测和过滤
-  - 内容安全性提升
-  - 违规内容拦截
-
-#### 🛡️ 敏感词系统增强
-- **统计分析功能** - 敏感词监控和分析
-  - 敏感词命中统计
-  - 数据分析报表
-  - 趋势分析和预警
-  - 过滤效果评估
-
-#### 📊 监控系统重构
-- **Prometheus监控集成** - 现代化监控方案
-  - 集成Prometheus和Grafana
-  - Spring Boot Actuator配置
-  - Micrometer Prometheus Registry
-  - JVM、HTTP、数据库连接池监控
-  - 预定义告警规则
-  - 完整的监控部署文档
-  - 移除旧的SQL调用树监控模块
-
-#### 🔧 认证系统优化
-- **Token管理优化** - 更好的用户体验
-  - 优化Token过期处理逻辑
-  - 改进Token续签机制
-  - 统一Sa-Token权限认证
-  - 管理员权限验证增强
-
-#### 📦 数据库更新
-- 新增博客相关表（blog_posts、blog_categories、blog_tags等）
-- 新增抽奖系统表（lottery_activities、lottery_prizes、lottery_records）
-- 新增社区标签表（community_tags）
-- 新增动态收藏表（moment_favorites、moment_views）
-- 新增敏感词统计表优化
+- 🆕 **博客系统**：Markdown 编辑、分类/标签、草稿箱、全文检索与评论互动。
+- 🆕 **抽奖中心**：活动配置、奖品管理、概率算法、中奖记录及后台运营。
+- 🆕 **标签体系统一**：社区/博客/动态共用标签维度，提供榜单与统计。
+- ✨ **动态功能增强**：动态收藏夹、推荐算法（点赞/评论/权重）、违规拦截、可视化报表。
+- 🛡️ **敏感词系统**：词库批量导入、命中记录、任务调度、接入 IM/动态/博客。
+- 📊 **监控重构**：Prometheus 指标拆分、JVM/HTTP/DB 监控、告警模板。
+- 🔐 **认证优化**：Token 生命周期管理、登录流程、统一异常语义。
+- 📦 **数据库更新**：新增博客、抽奖、标签、动态收藏等表结构。
 
 ### v1.4.0 🚀
 
-#### 🔐 权限系统重构
-- **Sa-Token认证系统迁移** - 从JWT迁移到Sa-Token
-  - 使用Sa-Token独立Redis存储（database 4）
-  - 支持管理员和用户双账号体系（StpAdminUtil / StpUserUtil）
-  - 完善的Session管理和Token续签机制
-  - 路由级权限拦截配置
-  - 优化的异常处理（401/403状态码）
-  - WebSocket Token认证支持
-
-#### 💬 IM聊天室模块
-- **实时聊天功能** - 基于WebSocket的即时通讯
-  - WebSocket实时消息推送
-  - 支持文本、图片、系统消息
-  - 在线用户列表和人数统计
-  - 历史消息加载（分页）
-  - 消息撤回功能（2分钟内）
-  - 心跳检测和断线重连
-  - 管理员功能：
-    - 消息管理和删除
-    - 用户踢出功能
-    - 系统公告推送
-    - 在线用户监控
-
-#### ⭐ 积分系统模块
-- **用户积分管理** - 完整的积分体系
-  - 积分规则配置和管理
-  - 积分明细记录和查询
-  - 用户积分统计
-  - 积分排行榜
-  - 支持多种积分变动类型
-  - 积分日志追踪
-
-#### 🔧 技术架构优化
-- **全局异常处理增强**
-  - Sa-Token异常统一处理
-  - NotLoginException → 401 状态码
-  - NotPermissionException → 403 状态码
-  - 详细的异常类型区分和消息提示
-
-- **WebSocket安全认证**
-  - Sa-Token握手拦截器
-  - Token验证和用户信息提取
-  - Session数据同步到WebSocket attributes
-
-- **模块化架构**
-  - xiaou-chat 聊天室模块
-  - xiaou-points 积分系统模块
-  - 模块间依赖优化
-
-#### 📦 数据库更新
-- 新增聊天室相关表（chat_rooms、chat_messages、chat_user_bans、chat_online_users）
-- 新增积分系统表（points_rules、user_points、points_detail）
+- 🔐 **Sa-Token 全面接管**：JWT 全量迁移至 Sa-Token，双端账号体系、并发控制、路由鉴权、WebSocket 鉴权。
+- 💬 **IM 聊天模块**：WebSocket 实时通信，文本/图片/系统消息、撤回、禁言、封禁、后台管理。
+- ⭐ **积分系统**：积分规则、明细、排行榜、任务中心。
+- 🧱 **架构优化**：全局异常处理增强、模块解耦、WebSocket 鉴权同步、敏感词中台。
+- 📦 **数据库**：新增聊天、积分相关表。
 
 ### v1.3.0 🔥
 
-#### 🚀 重大功能新增
-- **🤖 Coze AI工作流集成** - 引入智能AI工作流平台
-  - 支持Coze平台工作流调用
-  - 提供统一工具类和配置管理
-  - 同步和异步两种调用方式
-  - 参数传递、结果缓存、异常处理等完整功能
-  - 通过枚举统一管理工作流信息
+- 🤖 **Coze AI 集成**：统一 AI 能力封装，支持同步/异步调用、限流、异常治理。
+- 🎯 **Bug 趣味墙**：Bug 题库、抓取、分享、历史记录与运营活动。
+- 🧘 **摸鱼工作台**：每日任务、时薪统计、排行榜、提醒。
+- 🧰 **效率工具集**：常用开发工具聚合、清晰的路径引导。
+- 🎨 **用户体验**：前台 UI 重构、响应式布局、主题优化。
+- 🧠 **知识图谱强化**：节点内容升级、图谱编辑、后台维护流程。
+- 📦 **模块化**：`xiaou-moyu`、`xiaou-version` 等独立为可复用模块。
 
-- **🐛 Bug商店功能模块** - 趣味化编程体验
-  - Bug条目展示和管理系统
-  - 随机Bug获取和浏览功能
-  - 用户Bug浏览历史记录
-  - Bug内容复制和切换浏览
-  - 批量导入和数据初始化
-  - 管理端完整的CRUD操作
+### v1.2.x
 
-- **🎮 摸鱼工具集** - 程序员专属工具箱
-  - 程序员日历和每日内容管理
-  - 时薪计算器功能
-  - 今日热榜数据展示
-  - 热榜数据初始化和管理
+- 🛠️ **在线工具/简历 2.0**：多格式导出、版本管理、实时协作。
+- 🔔 **通知中心**：系统消息、站内信、订阅提醒。
+- 📁 **文件存储**：本地/云存储适配、权限控制、统计。
+- ⚙️ **系统优化**：SQL 规范化、结构调整、性能提升。
 
-- **🛠️ 开发者工具模块** - 提升开发效率
-  - 程序员工具模块集成
-  - 完善的工具路由配置
-  - 统一的工具管理界面
+### v1.1.x
 
-#### 🎨 用户体验优化
-- **导航系统升级** - 全局导航栏设计
-  - 统一的页面布局优化
-  - 响应式导航交互
-  - 更好的用户体验流程
-
-- **版本管理功能** - 系统版本追踪
-  - 版本历史管理和展示
-  - 菜单搜索功能实现
-  - 版本信息统一管理
-
-#### 🔧 技术架构优化
-- **知识图谱增强** - 知识管理系统完善
-  - 知识节点内容改为飞书文档链接
-  - 管理员端知识图谱和节点管理
-  - 更好的知识内容组织方式
-
-- **模块化架构** - 新增多个功能模块
-  - xiaou-moyu 摸鱼工具模块
-  - xiaou-version 版本管理模块
-  - 模块间依赖关系优化
-
-### v1.2.1
-
-#### 🚀 新增功能
-- **敏感词过滤系统** - 完善的内容审核机制
-  - 支持敏感词分类管理
-  - 多种过滤策略配置
-  - 敏感词检测日志记录
-  - 实时内容过滤与替换
-
-#### 🔧 系统优化
-- 优化通知模块性能和功能
-- 完善各模块间的集成和协作
-- 提升系统稳定性和可维护性
-
-### v1.2.0
-
-#### 🚀 新增功能模块
-- **朋友圈模块** - 全新的社交功能
-  - 用户动态发布与展示
-  - 点赞、评论、转发功能
-  - 动态可见性控制
-  - 图片/视频多媒体支持
-  
-- **消息通知模块** - 完整的消息推送系统
-  - 系统消息通知
-  - 用户互动消息
-  - 消息状态管理
-  - 批量操作支持
-  
-- **文件存储模块** - 统一的文件管理系统
-  - 多种存储策略支持(本地、云存储)
-  - 文件上传下载管理
-  - 文件访问权限控制
-  - 存储统计与监控
-
-#### 🔧 技术改进
-- 完善模块化架构设计
-- 优化系统安全性
-- 提升用户体验
-
-### v1.1.1 
-
-#### 🔧 技术改进
-- 重构SQL监控系统，优化为监控树类型结构
-- 提升监控数据可视化展示效果
-- 优化监控性能和用户体验
-
-### v1.1.0
-
-#### 🚀 功能增强
-- 新增社区模块
-- 社区帖子管理
-- 评论系统
-- 用户互动功能
-
-#### 🔧 技术改进
-- 优化系统架构
-- 代码结构重构
-- 性能优化
+- ✨ **功能增强**：招聘/内推模块、问答、用户中心、数据结构升级。
+- 🧱 **架构优化**：模块抽象、代码重构、性能调优。
 
 ### v1.0.0
 
-#### 🎉 首次发布
-
-**核心功能**
-- 后台管理
-- 面试题管理
+- 🎉 初始发布，包含后台管理与基础题库/内容功能。
 
 ## 📞 联系方式
 
-- 项目维护者: xiaou
-- 邮箱: 3153566913@qq.com
-- 项目地址: https://github.com/xiaou61/Code-Nest
+- 维护者：xiaou
+- 邮箱：3153566913@qq.com
+- GitHub：https://github.com/xiaou61/Code-Nest
 
 ## 📜 开源协议
 
-本项目基于 [MIT License](LICENSE) 开源协议。
+本项目采用 [MIT License](LICENSE)。欢迎 Star / Fork，一起共建生态。
 
-**⭐ 如果这个项目对你有帮助，请点个Star支持一下！⭐**
-
-## 项目功能截图
+## 🖼️ 功能截图
 
 ### 管理员端
 
 ![image-20251001192022408](https://11-1305448902.cos.ap-chengdu.myqcloud.com/imgs/202510011920552.png)
-
 ![image-20251001192046724](https://11-1305448902.cos.ap-chengdu.myqcloud.com/imgs/202510011920794.png)
-
 ![image-20251001192101335](https://11-1305448902.cos.ap-chengdu.myqcloud.com/imgs/202510011921406.png)
-
 ![image-20251001192116123](https://11-1305448902.cos.ap-chengdu.myqcloud.com/imgs/202510011921200.png)
-
 ![image-20251001192148551](https://11-1305448902.cos.ap-chengdu.myqcloud.com/imgs/202510011921665.png)
 
 ### 用户端
 
 ![image-20251001192200120](https://11-1305448902.cos.ap-chengdu.myqcloud.com/imgs/202510011922393.png)
-
 ![image-20251001192206833](https://11-1305448902.cos.ap-chengdu.myqcloud.com/imgs/202510011922904.png)
-
 ![image-20251001192254045](https://11-1305448902.cos.ap-chengdu.myqcloud.com/imgs/202510011922111.png)
-
 ![image-20251001192300510](https://11-1305448902.cos.ap-chengdu.myqcloud.com/imgs/202510011923575.png)
-
 ![image-20251001192306591](https://11-1305448902.cos.ap-chengdu.myqcloud.com/imgs/202510011923659.png)
-
 ![image-20251001192312505](https://11-1305448902.cos.ap-chengdu.myqcloud.com/imgs/202510011923749.png)
-
 ![image-20251001192320125](https://11-1305448902.cos.ap-chengdu.myqcloud.com/imgs/202510011923340.png)
-
 ![image-20251001192329371](https://11-1305448902.cos.ap-chengdu.myqcloud.com/imgs/202510011923495.png)
-

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Code Nest
 
-![Version](https://img.shields.io/badge/version-1.6.0-blue.svg)
+![Version](https://img.shields.io/badge/version-1.6.1-blue.svg)
 ![Java](https://img.shields.io/badge/java-17-orange.svg)
 ![Spring Boot](https://img.shields.io/badge/spring%20boot-3.4.4-brightgreen.svg)
 ![Vue](https://img.shields.io/badge/vue-3.x-4fc08d.svg)
@@ -87,6 +87,7 @@ Code Nest 是一个面向开发者的成长型社区与知识运营平台，采�
 | xiaou-version | 版本档案 | 版本时间线、发布记录、变更说明 |
 | xiaou-moyu | 摸鱼面板 | 日常任务、健康打卡、工作台 |
 | xiaou-points | 积分体系 | 积分规则、账户、排行榜、明细 |
+| xiaou-plan | 计划打卡 | 个人计划、每日打卡、连续统计、提醒通知 |
 | xiaou-monitor | SQL/监控 | SQL 采集、慢查询、日志审计、观测面板 |
 
 ### 前端应用
@@ -354,6 +355,15 @@ server {
 ## 📝 更新日志
 
 仅列出最近版本，更多历史可查看 `git log`。
+
+### v1.6.1 ✨
+
+- 🆕 **计划打卡模块**：`xiaou-plan` 支持个人计划创建、每日打卡、连续打卡统计、站内提醒通知、打卡记录查询等功能。
+- 🎨 **首页重新设计**：采用现代卡片式布局，新增 Hero 区域、核心功能展示、快速入口网格、特色亮点区域，提升视觉体验。
+- 📱 **面试详情页优化**：优化移动端适配与样式细节，提升手机端刷题体验。
+- 🗄️ **数据库脚本**：`sql/v1.6.1` 新增计划打卡相关表结构（user_plan、plan_checkin_record、plan_remind_task）。
+- 🔔 **定时任务**：计划模块集成提醒调度器，支持每日任务生成与站内通知推送。
+- 🔧 **导航优化**：首页快速入口新增「计划打卡」，顶部导航「学习」菜单新增入口。
 
 ### v1.6.0 🚀
 

--- a/docs/PRD/个人计划打卡模块PRD-v1.0.0.md
+++ b/docs/PRD/个人计划打卡模块PRD-v1.0.0.md
@@ -1,0 +1,602 @@
+# 个人计划打卡模块 PRD v1.0.0
+
+## 📋 项目概述
+
+### 🎯 项目背景
+程序员在日常工作学习中，经常需要制定各种计划任务，如刷题计划、阅读计划、学习计划等。为了帮助用户更好地管理个人目标、养成良好习惯，需要建立一套完整的个人计划打卡系统。通过任务提醒、进度追踪、数据统计等功能，提升用户的任务完成率和学习效率。
+
+### 💡 核心价值
+- **目标管理**: 帮助用户制定和管理个人学习/工作计划
+- **习惯养成**: 通过打卡机制培养用户的持续执行习惯
+- **及时提醒**: 多渠道任务提醒，确保用户不错过重要任务
+- **进度追踪**: 可视化展示任务完成进度和历史记录
+- **数据分析**: 统计分析用户的计划执行情况，提供改进建议
+- **积分激励**: 与积分系统打通，完成计划可获得额外积分奖励
+
+### 🏠 模块定位
+建议将该模块作为独立的 `xiaou-plan` 模块，同时在前端 `vue3-user-front` 的摸鱼工具或独立菜单中展示。该模块与以下模块存在关联：
+- **xiaou-points**: 完成计划任务可获得积分奖励
+- **xiaou-notification**: 复用通知模块发送任务提醒
+- **xiaou-interview**: 可创建与刷题相关的计划任务
+
+## 🚀 功能需求
+
+### 1. 计划管理
+
+#### 1.1 创建计划
+- **计划类型**: 支持多种类型（刷题计划、学习计划、阅读计划、运动计划、自定义计划）
+- **计划名称**: 用户自定义计划名称，如"每日刷3道算法题"
+- **计划描述**: 可选的详细描述说明
+- **目标设定**: 
+  - 数量目标：如"完成10道题"
+  - 时长目标：如"学习2小时"
+  - 次数目标：如"打卡7天"
+- **时间设置**:
+  - 开始日期：计划生效日期
+  - 结束日期：计划截止日期（可选，支持长期计划）
+  - 每日开始时间：当日任务的预计开始时间
+  - 每日截止时间：当日任务的截止时间
+- **重复规则**:
+  - 每日：每天都需要完成
+  - 工作日：仅周一至周五
+  - 周末：仅周六周日
+  - 自定义：选择特定星期几
+- **提醒设置**:
+  - 提前提醒时间：任务开始前N分钟提醒
+  - 截止提醒：任务截止前N分钟再次提醒
+  - 提醒渠道：站内通知/浏览器推送/邮件
+
+#### 1.2 计划列表
+- **状态筛选**: 进行中/已完成/已过期/已暂停
+- **类型筛选**: 按计划类型筛选
+- **排序方式**: 按创建时间/截止时间/完成率排序
+- **搜索功能**: 支持按计划名称搜索
+- **快捷操作**: 暂停/恢复/删除/编辑计划
+
+#### 1.3 计划详情
+- **基本信息**: 计划名称、描述、时间范围、重复规则
+- **进度展示**: 已完成/总目标的进度条
+- **打卡日历**: 日历视图展示每日打卡情况
+- **历史记录**: 所有打卡记录列表
+
+### 2. 打卡功能
+
+#### 2.1 今日任务
+- **任务列表**: 展示当日需要完成的所有计划任务
+- **任务状态**: 待完成/进行中/已完成/已过期
+- **倒计时**: 显示距离任务截止的剩余时间
+- **快捷打卡**: 一键完成简单任务的打卡
+
+#### 2.2 打卡记录
+- **打卡时间**: 精确到秒的打卡时间记录
+- **完成内容**: 记录具体完成的内容（可选）
+- **完成数量**: 记录完成的数量（如刷了几道题）
+- **心得备注**: 用户可添加学习心得或备注
+- **附件上传**: 支持上传截图作为完成证明（可选）
+
+#### 2.3 补打卡
+- **补卡规则**: 允许补打最近N天内未完成的任务
+- **补卡限制**: 每月最多补卡N次
+- **补卡标记**: 补卡记录会有特殊标记
+
+### 3. 提醒系统
+
+#### 3.1 站内通知
+- **实现方式**: 复用现有 `xiaou-notification` 模块
+- **通知内容**: 任务标题、开始/截止时间、快捷打卡链接
+- **通知时机**: 
+  - 任务开始前提醒
+  - 任务即将截止提醒
+  - 连续打卡里程碑提醒
+- **通知类型**: 使用 `SYSTEM` 类型的个人消息
+
+### 4. 数据统计
+
+#### 4.1 个人统计
+- **总览数据**: 
+  - 累计创建计划数
+  - 累计打卡次数
+  - 总完成率
+  - 最长连续打卡天数
+- **周期统计**:
+  - 本周完成情况
+  - 本月完成情况
+  - 自定义时间段统计
+- **趋势图表**:
+  - 每日打卡趋势折线图
+  - 各类型计划饼图
+  - 完成率变化曲线
+
+#### 4.2 成就系统
+- **连续打卡成就**: 连续7天/30天/100天打卡徽章
+- **完成数量成就**: 累计完成100/500/1000次任务
+- **早起打卡成就**: 早上6点前完成打卡
+- **全勤成就**: 某月全勤打卡
+
+### 5. 积分联动
+
+#### 5.1 积分奖励规则
+- **单次打卡**: 每次完成打卡获得10积分
+- **连续打卡**: 连续7天额外奖励50积分
+- **计划完成**: 完成整个计划额外奖励100积分
+- **成就解锁**: 解锁成就获得对应积分奖励
+
+#### 5.2 积分类型扩展
+```java
+public enum PointsType {
+    ADMIN_GRANT(1, "后台发放"),
+    CHECK_IN(2, "打卡积分"),
+    PLAN_COMPLETE(3, "计划打卡"), // 新增
+    ACHIEVEMENT(4, "成就奖励");  // 新增
+}
+```
+
+## 🔧 技术实现方案
+
+### 1. 数据库设计
+
+#### 1.1 计划表（user_plan）
+```sql
+CREATE TABLE user_plan (
+    id BIGINT PRIMARY KEY AUTO_INCREMENT COMMENT '计划ID',
+    user_id BIGINT NOT NULL COMMENT '用户ID',
+    plan_name VARCHAR(100) NOT NULL COMMENT '计划名称',
+    plan_desc VARCHAR(500) COMMENT '计划描述',
+    plan_type TINYINT NOT NULL COMMENT '计划类型：1-刷题 2-学习 3-阅读 4-运动 5-自定义',
+    target_type TINYINT NOT NULL COMMENT '目标类型：1-数量 2-时长 3-次数',
+    target_value INT NOT NULL COMMENT '目标值',
+    target_unit VARCHAR(20) COMMENT '目标单位（道/小时/次）',
+    start_date DATE NOT NULL COMMENT '开始日期',
+    end_date DATE COMMENT '结束日期（NULL表示长期）',
+    daily_start_time TIME COMMENT '每日开始时间',
+    daily_end_time TIME COMMENT '每日截止时间',
+    repeat_type TINYINT NOT NULL DEFAULT 1 COMMENT '重复类型：1-每日 2-工作日 3-周末 4-自定义',
+    repeat_days VARCHAR(20) COMMENT '自定义重复日（如：1,2,3,4,5）',
+    remind_before INT DEFAULT 30 COMMENT '提前提醒分钟数',
+    remind_deadline INT DEFAULT 10 COMMENT '截止提醒分钟数',
+    remind_channels VARCHAR(50) DEFAULT 'notification' COMMENT '提醒渠道：notification,webpush,email',
+    status TINYINT NOT NULL DEFAULT 1 COMMENT '状态：0-已删除 1-进行中 2-已暂停 3-已完成 4-已过期',
+    total_checkin_days INT DEFAULT 0 COMMENT '累计打卡天数',
+    current_streak INT DEFAULT 0 COMMENT '当前连续打卡天数',
+    max_streak INT DEFAULT 0 COMMENT '最长连续打卡天数',
+    create_time DATETIME DEFAULT CURRENT_TIMESTAMP COMMENT '创建时间',
+    update_time DATETIME DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP COMMENT '更新时间',
+    
+    INDEX idx_user_id (user_id),
+    INDEX idx_status (status),
+    INDEX idx_user_status (user_id, status),
+    INDEX idx_start_date (start_date),
+    INDEX idx_end_date (end_date)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci COMMENT='用户计划表';
+```
+
+#### 1.2 打卡记录表（plan_checkin_record）
+```sql
+CREATE TABLE plan_checkin_record (
+    id BIGINT PRIMARY KEY AUTO_INCREMENT COMMENT '记录ID',
+    plan_id BIGINT NOT NULL COMMENT '计划ID',
+    user_id BIGINT NOT NULL COMMENT '用户ID',
+    checkin_date DATE NOT NULL COMMENT '打卡日期',
+    checkin_time DATETIME NOT NULL COMMENT '打卡时间',
+    complete_value INT COMMENT '完成数量',
+    complete_content VARCHAR(500) COMMENT '完成内容描述',
+    remark VARCHAR(500) COMMENT '心得备注',
+    attachment_url VARCHAR(500) COMMENT '附件URL',
+    is_supplement TINYINT DEFAULT 0 COMMENT '是否补卡：0-否 1-是',
+    points_earned INT DEFAULT 0 COMMENT '获得积分',
+    create_time DATETIME DEFAULT CURRENT_TIMESTAMP COMMENT '创建时间',
+    
+    UNIQUE KEY uk_plan_date (plan_id, checkin_date),
+    INDEX idx_user_id (user_id),
+    INDEX idx_plan_id (plan_id),
+    INDEX idx_checkin_date (checkin_date),
+    INDEX idx_user_date (user_id, checkin_date)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci COMMENT='计划打卡记录表';
+```
+
+#### 1.3 提醒任务表（plan_remind_task）
+```sql
+CREATE TABLE plan_remind_task (
+    id BIGINT PRIMARY KEY AUTO_INCREMENT COMMENT '任务ID',
+    plan_id BIGINT NOT NULL COMMENT '计划ID',
+    user_id BIGINT NOT NULL COMMENT '用户ID',
+    remind_type TINYINT NOT NULL COMMENT '提醒类型：1-开始提醒 2-截止提醒',
+    remind_time DATETIME NOT NULL COMMENT '提醒时间',
+    status TINYINT DEFAULT 0 COMMENT '状态：0-待发送 1-已发送 2-已取消',
+    send_time DATETIME COMMENT '实际发送时间',
+    create_time DATETIME DEFAULT CURRENT_TIMESTAMP COMMENT '创建时间',
+    
+    INDEX idx_remind_time (remind_time),
+    INDEX idx_status (status),
+    INDEX idx_plan_id (plan_id)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci COMMENT='计划提醒任务表';
+```
+
+### 2. 后端接口设计
+
+#### 2.1 计划管理接口（/user/plan）
+```
+POST /user/plan/create              # 创建计划
+PUT  /user/plan/update              # 更新计划
+DELETE /user/plan/{id}              # 删除计划
+GET  /user/plan/{id}                # 获取计划详情
+POST /user/plan/list                # 获取计划列表（分页）
+PUT  /user/plan/{id}/pause          # 暂停计划
+PUT  /user/plan/{id}/resume         # 恢复计划
+```
+
+#### 2.2 打卡接口（/user/plan/checkin）
+```
+POST /user/plan/checkin             # 执行打卡
+POST /user/plan/checkin/supplement  # 补打卡
+GET  /user/plan/{id}/checkin/list   # 获取打卡记录列表
+GET  /user/plan/today-tasks         # 获取今日任务列表
+GET  /user/plan/checkin/calendar    # 获取打卡日历数据
+```
+
+#### 2.3 统计接口（/user/plan/stats）
+```
+GET  /user/plan/stats/overview      # 获取统计总览
+GET  /user/plan/stats/trend         # 获取趋势数据
+GET  /user/plan/stats/achievements  # 获取成就列表
+```
+
+#### 2.4 提醒设置接口（/user/plan/remind）
+```
+POST /user/plan/remind/subscribe    # 订阅 Web Push
+DELETE /user/plan/remind/unsubscribe # 取消订阅
+PUT  /user/plan/remind/settings     # 更新提醒设置
+GET  /user/plan/remind/settings     # 获取提醒设置
+```
+
+### 3. 提醒服务实现
+
+#### 3.1 定时任务调度
+```java
+@Component
+public class PlanRemindScheduler {
+    
+    @Autowired
+    private PlanRemindService remindService;
+    
+    /**
+     * 每分钟扫描待发送的提醒任务
+     */
+    @Scheduled(cron = "0 * * * * ?")
+    public void scanRemindTasks() {
+        LocalDateTime now = LocalDateTime.now();
+        LocalDateTime oneMinuteLater = now.plusMinutes(1);
+        
+        // 查询即将到期的提醒任务
+        List<PlanRemindTask> tasks = remindService.getPendingTasks(now, oneMinuteLater);
+        
+        for (PlanRemindTask task : tasks) {
+            remindService.sendRemind(task);
+        }
+    }
+    
+    /**
+     * 每天凌晨生成当日的提醒任务
+     */
+    @Scheduled(cron = "0 0 0 * * ?")
+    public void generateDailyRemindTasks() {
+        remindService.generateTodayTasks();
+    }
+}
+```
+
+#### 3.2 Web Push 服务
+```java
+@Service
+public class WebPushService {
+    
+    private final String publicKey = "VAPID_PUBLIC_KEY";
+    private final String privateKey = "VAPID_PRIVATE_KEY";
+    
+    /**
+     * 发送 Web Push 通知
+     */
+    public void sendPushNotification(Long userId, PushMessage message) {
+        List<UserPushSubscription> subscriptions = getActiveSubscriptions(userId);
+        
+        for (UserPushSubscription sub : subscriptions) {
+            try {
+                Notification notification = new Notification(
+                    sub.getEndpoint(),
+                    sub.getP256dhKey(),
+                    sub.getAuthKey(),
+                    message.toJson()
+                );
+                
+                PushService pushService = new PushService(publicKey, privateKey);
+                pushService.send(notification);
+            } catch (Exception e) {
+                // 推送失败，标记订阅失效
+                markSubscriptionInvalid(sub.getId());
+            }
+        }
+    }
+}
+```
+
+#### 3.3 多渠道提醒策略
+```java
+@Service
+public class PlanRemindService {
+    
+    @Autowired
+    private NotificationService notificationService;
+    @Autowired
+    private WebPushService webPushService;
+    @Autowired
+    private EmailService emailService;
+    
+    public void sendRemind(PlanRemindTask task) {
+        String[] channels = task.getRemindChannels().split(",");
+        UserPlan plan = getPlanById(task.getPlanId());
+        
+        RemindContent content = buildRemindContent(plan, task);
+        
+        for (String channel : channels) {
+            switch (channel) {
+                case "notification":
+                    // 站内通知
+                    notificationService.sendSystemNotification(
+                        task.getUserId(),
+                        content.getTitle(),
+                        content.getBody(),
+                        "/plan/" + plan.getId()
+                    );
+                    break;
+                case "webpush":
+                    // 浏览器推送
+                    webPushService.sendPushNotification(
+                        task.getUserId(),
+                        new PushMessage(content.getTitle(), content.getBody(), "/plan")
+                    );
+                    break;
+                case "email":
+                    // 邮件提醒
+                    emailService.sendPlanRemind(task.getUserId(), content);
+                    break;
+            }
+        }
+        
+        // 更新任务状态
+        updateTaskStatus(task.getId(), RemindStatus.SENT);
+    }
+}
+```
+
+### 4. 前端实现要点
+
+#### 4.1 Service Worker 注册（Web Push）
+```javascript
+// public/sw.js
+self.addEventListener('push', function(event) {
+  const data = event.data.json();
+  
+  const options = {
+    body: data.body,
+    icon: '/logo.png',
+    badge: '/badge.png',
+    data: {
+      url: data.url
+    },
+    actions: [
+      { action: 'checkin', title: '立即打卡' },
+      { action: 'later', title: '稍后提醒' }
+    ]
+  };
+  
+  event.waitUntil(
+    self.registration.showNotification(data.title, options)
+  );
+});
+
+self.addEventListener('notificationclick', function(event) {
+  event.notification.close();
+  
+  if (event.action === 'checkin') {
+    event.waitUntil(
+      clients.openWindow(event.notification.data.url)
+    );
+  }
+});
+```
+
+#### 4.2 订阅 Web Push
+```javascript
+// utils/webpush.js
+export async function subscribePush() {
+  if (!('serviceWorker' in navigator) || !('PushManager' in window)) {
+    console.warn('浏览器不支持 Web Push');
+    return null;
+  }
+  
+  const registration = await navigator.serviceWorker.ready;
+  
+  const subscription = await registration.pushManager.subscribe({
+    userVisibleOnly: true,
+    applicationServerKey: urlBase64ToUint8Array(VAPID_PUBLIC_KEY)
+  });
+  
+  // 将订阅信息发送到服务器保存
+  await api.post('/user/plan/remind/subscribe', {
+    endpoint: subscription.endpoint,
+    p256dh: btoa(String.fromCharCode(...new Uint8Array(subscription.getKey('p256dh')))),
+    auth: btoa(String.fromCharCode(...new Uint8Array(subscription.getKey('auth'))))
+  });
+  
+  return subscription;
+}
+```
+
+## 📱 用户体验流程
+
+### 1. 创建计划流程
+1. 用户点击"创建计划"按钮
+2. 选择计划类型（刷题/学习/自定义等）
+3. 填写计划名称和目标
+4. 设置时间范围和重复规则
+5. 配置提醒方式和时间
+6. 确认创建，系统生成提醒任务
+
+### 2. 日常打卡流程
+1. 用户收到任务开始提醒
+2. 进入今日任务页面查看待完成任务
+3. 完成任务后点击打卡
+4. 填写完成内容/数量（可选）
+5. 系统记录打卡并发放积分
+6. 更新连续打卡天数和统计数据
+
+### 3. 查看统计流程
+1. 进入统计页面查看总览数据
+2. 查看打卡日历和趋势图表
+3. 查看已解锁的成就徽章
+4. 查看各计划的完成率排名
+
+## 📐 前端界面设计
+
+### 1. 今日任务页面
+```
+┌─────────────────────────────────────────┐
+│ 📅 今日任务                    2025-12-10 │
+├─────────────────────────────────────────┤
+│ ┌─────────────────────────────────────┐ │
+│ │ 🔥 每日刷3道算法题                   │ │
+│ │ ⏰ 09:00 - 12:00  剩余 2小时15分     │ │
+│ │ 📊 目标：3道  已完成：1道            │ │
+│ │                         [打卡]       │ │
+│ └─────────────────────────────────────┘ │
+│                                         │
+│ ┌─────────────────────────────────────┐ │
+│ │ ✅ 阅读技术文档30分钟    已完成      │ │
+│ │ ⏰ 14:00 - 15:00                    │ │
+│ │ 📝 完成内容：阅读了Vue3组合式API文档  │ │
+│ └─────────────────────────────────────┘ │
+│                                         │
+│ ┌─────────────────────────────────────┐ │
+│ │ ⏳ 背诵10个英语单词                  │ │
+│ │ ⏰ 20:00 - 21:00  尚未开始           │ │
+│ │ 📊 目标：10个                        │ │
+│ └─────────────────────────────────────┘ │
+├─────────────────────────────────────────┤
+│ 📈 今日进度：2/3 完成  🔥 连续打卡：5天  │
+└─────────────────────────────────────────┘
+```
+
+### 2. 计划详情页面
+```
+┌─────────────────────────────────────────┐
+│ ← 每日刷3道算法题                        │
+├─────────────────────────────────────────┤
+│ 📊 完成进度                              │
+│ ████████████░░░░░░░░░░ 60%              │
+│ 已完成 18/30 天                          │
+├─────────────────────────────────────────┤
+│ 🔥 连续打卡                              │
+│ 当前：5天  最长：12天                    │
+├─────────────────────────────────────────┤
+│ 📅 打卡日历  < 2025年12月 >              │
+│ 日 一 二 三 四 五 六                     │
+│  1  2  3  4  5  6  7                    │
+│ ✓  ✓  ✓  -  ✓  ✓  ✓                    │
+│  8  9 10 11 12 13 14                    │
+│ ✓  ✓  ○                                │
+├─────────────────────────────────────────┤
+│ ⏰ 提醒设置                              │
+│ 开始提醒：08:45  截止提醒：11:50         │
+│ 渠道：站内通知 ✓  浏览器推送 ✓  邮件 ○   │
+├─────────────────────────────────────────┤
+│ [编辑计划]  [暂停计划]  [删除计划]       │
+└─────────────────────────────────────────┘
+```
+
+### 3. 统计总览页面
+```
+┌─────────────────────────────────────────┐
+│ 📊 我的计划统计                          │
+├─────────────────────────────────────────┤
+│ ┌─────────┐ ┌─────────┐ ┌─────────┐    │
+│ │  5      │ │  128    │ │  86%    │    │
+│ │ 进行中  │ │ 累计打卡│ │ 完成率  │    │
+│ └─────────┘ └─────────┘ └─────────┘    │
+├─────────────────────────────────────────┤
+│ 📈 本周打卡趋势                          │
+│     7 ─┐                                │
+│     5 ─┼─────●─────●                    │
+│     3 ─┼──●─────●─────●                 │
+│     1 ─┼─────────────────●              │
+│        └──周一─周二─周三─周四─周五──    │
+├─────────────────────────────────────────┤
+│ 🏆 成就墙                                │
+│ [🔥7天] [🌟30天] [⭐100次] [🌅早起]      │
+│                                         │
+│ 下一个成就：连续打卡30天  还需25天       │
+└─────────────────────────────────────────┘
+```
+
+## ✅ 实现范围
+
+### 第一期功能（v1.0.0）
+- ✅ **计划CRUD**: 创建、编辑、删除、查询计划
+- ✅ **基础打卡**: 今日任务展示和打卡功能
+- ✅ **站内通知**: 复用notification模块发送提醒
+- ✅ **连续打卡**: 连续打卡天数统计和显示
+- ✅ **基础统计**: 完成率、打卡天数等基础统计
+- ✅ **积分联动**: 打卡获得积分奖励
+
+### 第二期功能（v1.1.0）
+- 🔲 **Web Push**: 浏览器推送通知功能
+- 🔲 **打卡日历**: 日历视图展示打卡情况
+- 🔲 **补打卡**: 支持补打最近N天的任务
+- 🔲 **邮件提醒**: 可选的邮件提醒功能
+- 🔲 **趋势图表**: 打卡趋势和统计图表
+
+### 第三期功能（v1.2.0）
+- 🔲 **成就系统**: 成就徽章和解锁奖励
+- 🔲 **数据导出**: 导出打卡记录和统计报表
+- 🔲 **计划模板**: 提供常用计划模板一键创建
+- 🔲 **社交分享**: 分享打卡成果到社区/朋友圈
+
+## 📝 附录
+
+### A. 计划类型枚举
+```java
+public enum PlanType {
+    CODING(1, "刷题计划", "💻"),
+    STUDY(2, "学习计划", "📚"),
+    READING(3, "阅读计划", "📖"),
+    EXERCISE(4, "运动计划", "🏃"),
+    CUSTOM(5, "自定义", "✏️");
+}
+```
+
+### B. 成就类型定义
+```java
+public enum AchievementType {
+    STREAK_7("streak_7", "连续打卡7天", "🔥", 50),
+    STREAK_30("streak_30", "连续打卡30天", "🌟", 200),
+    STREAK_100("streak_100", "连续打卡100天", "👑", 500),
+    TOTAL_100("total_100", "累计打卡100次", "⭐", 100),
+    TOTAL_500("total_500", "累计打卡500次", "💎", 300),
+    EARLY_BIRD("early_bird", "早起打卡(6点前)", "🌅", 30),
+    FULL_MONTH("full_month", "月度全勤", "🏆", 150);
+}
+```
+
+### C. 提醒消息模板
+```
+【开始提醒】
+标题：📋 {计划名称} 即将开始
+内容：您的任务「{计划名称}」将在{开始时间}开始，目标：{目标描述}。加油！
+
+【截止提醒】
+标题：⏰ {计划名称} 即将截止
+内容：您的任务「{计划名称}」将在{截止时间}截止，还未完成哦~
+
+【连续打卡里程碑】
+标题：🎉 恭喜达成{天数}天连续打卡！
+内容：您已连续打卡{天数}天，获得{积分}积分奖励！继续保持！
+```

--- a/pom-xml-flattened
+++ b/pom-xml-flattened
@@ -27,6 +27,7 @@
     <module>xiaou-blog</module>
     <module>xiaou-codepen</module>
     <module>xiaou-resume</module>
+    <module>xiaou-plan</module>
   </modules>
   <properties>
     <maven-jar-plugin.version>3.2.2</maven-jar-plugin.version>

--- a/pom.xml
+++ b/pom.xml
@@ -29,6 +29,7 @@
         <module>xiaou-blog</module>
         <module>xiaou-codepen</module>
         <module>xiaou-resume</module>
+        <module>xiaou-plan</module>
     </modules>
 
     <properties>

--- a/sql/v1.6.1/plan_checkin.sql
+++ b/sql/v1.6.1/plan_checkin.sql
@@ -1,0 +1,75 @@
+-- =============================================
+-- 个人计划打卡模块 SQL v1.6.1
+-- =============================================
+
+-- 1. 用户计划表
+CREATE TABLE IF NOT EXISTS user_plan (
+    id BIGINT PRIMARY KEY AUTO_INCREMENT COMMENT '计划ID',
+    user_id BIGINT NOT NULL COMMENT '用户ID',
+    plan_name VARCHAR(100) NOT NULL COMMENT '计划名称',
+    plan_desc VARCHAR(500) COMMENT '计划描述',
+    plan_type TINYINT NOT NULL COMMENT '计划类型：1-刷题 2-学习 3-阅读 4-运动 5-自定义',
+    target_type TINYINT NOT NULL DEFAULT 1 COMMENT '目标类型：1-数量 2-时长 3-次数',
+    target_value INT NOT NULL DEFAULT 1 COMMENT '目标值',
+    target_unit VARCHAR(20) DEFAULT '次' COMMENT '目标单位（道/小时/次）',
+    start_date DATE NOT NULL COMMENT '开始日期',
+    end_date DATE COMMENT '结束日期（NULL表示长期）',
+    daily_start_time TIME COMMENT '每日开始时间',
+    daily_end_time TIME COMMENT '每日截止时间',
+    repeat_type TINYINT NOT NULL DEFAULT 1 COMMENT '重复类型：1-每日 2-工作日 3-周末 4-自定义',
+    repeat_days VARCHAR(20) COMMENT '自定义重复日（如：1,2,3,4,5 表示周一到周五）',
+    remind_before INT DEFAULT 30 COMMENT '提前提醒分钟数',
+    remind_deadline INT DEFAULT 10 COMMENT '截止提醒分钟数',
+    remind_enabled TINYINT DEFAULT 1 COMMENT '是否启用提醒：0-否 1-是',
+    status TINYINT NOT NULL DEFAULT 1 COMMENT '状态：0-已删除 1-进行中 2-已暂停 3-已完成 4-已过期',
+    total_checkin_days INT DEFAULT 0 COMMENT '累计打卡天数',
+    current_streak INT DEFAULT 0 COMMENT '当前连续打卡天数',
+    max_streak INT DEFAULT 0 COMMENT '最长连续打卡天数',
+    create_time DATETIME DEFAULT CURRENT_TIMESTAMP COMMENT '创建时间',
+    update_time DATETIME DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP COMMENT '更新时间',
+    
+    INDEX idx_user_id (user_id),
+    INDEX idx_status (status),
+    INDEX idx_user_status (user_id, status),
+    INDEX idx_start_date (start_date),
+    INDEX idx_end_date (end_date)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci COMMENT='用户计划表';
+
+-- 2. 计划打卡记录表
+CREATE TABLE IF NOT EXISTS plan_checkin_record (
+    id BIGINT PRIMARY KEY AUTO_INCREMENT COMMENT '记录ID',
+    plan_id BIGINT NOT NULL COMMENT '计划ID',
+    user_id BIGINT NOT NULL COMMENT '用户ID',
+    checkin_date DATE NOT NULL COMMENT '打卡日期',
+    checkin_time DATETIME NOT NULL COMMENT '打卡时间',
+    complete_value INT COMMENT '完成数量',
+    complete_content VARCHAR(500) COMMENT '完成内容描述',
+    remark VARCHAR(500) COMMENT '心得备注',
+    is_supplement TINYINT DEFAULT 0 COMMENT '是否补卡：0-否 1-是',
+    points_earned INT DEFAULT 0 COMMENT '获得积分',
+    create_time DATETIME DEFAULT CURRENT_TIMESTAMP COMMENT '创建时间',
+    
+    UNIQUE KEY uk_plan_date (plan_id, checkin_date),
+    INDEX idx_user_id (user_id),
+    INDEX idx_plan_id (plan_id),
+    INDEX idx_checkin_date (checkin_date),
+    INDEX idx_user_date (user_id, checkin_date)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci COMMENT='计划打卡记录表';
+
+-- 3. 计划提醒任务表
+CREATE TABLE IF NOT EXISTS plan_remind_task (
+    id BIGINT PRIMARY KEY AUTO_INCREMENT COMMENT '任务ID',
+    plan_id BIGINT NOT NULL COMMENT '计划ID',
+    user_id BIGINT NOT NULL COMMENT '用户ID',
+    remind_type TINYINT NOT NULL COMMENT '提醒类型：1-开始提醒 2-截止提醒',
+    remind_date DATE NOT NULL COMMENT '提醒日期',
+    remind_time DATETIME NOT NULL COMMENT '提醒时间',
+    status TINYINT DEFAULT 0 COMMENT '状态：0-待发送 1-已发送 2-已取消',
+    send_time DATETIME COMMENT '实际发送时间',
+    create_time DATETIME DEFAULT CURRENT_TIMESTAMP COMMENT '创建时间',
+    
+    INDEX idx_remind_time (remind_time),
+    INDEX idx_status (status),
+    INDEX idx_plan_id (plan_id),
+    INDEX idx_remind_date_status (remind_date, status)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci COMMENT='计划提醒任务表';

--- a/vue3-user-front/src/App.vue
+++ b/vue3-user-front/src/App.vue
@@ -44,6 +44,10 @@
                   <el-icon><DataAnalysis /></el-icon>
                   知识图谱
                 </el-dropdown-item>
+                <el-dropdown-item command="/plan">
+                  <el-icon><Calendar /></el-icon>
+                  计划打卡
+                </el-dropdown-item>
               </el-dropdown-menu>
             </template>
           </el-dropdown>

--- a/vue3-user-front/src/api/plan.js
+++ b/vue3-user-front/src/api/plan.js
@@ -1,0 +1,63 @@
+import request from '@/utils/request'
+
+/**
+ * 计划打卡相关API
+ */
+export const planApi = {
+  // 创建计划
+  createPlan(data) {
+    return request.post('/user/plan/create', data)
+  },
+
+  // 更新计划
+  updatePlan(planId, data) {
+    return request.put(`/user/plan/update/${planId}`, data)
+  },
+
+  // 删除计划
+  deletePlan(planId) {
+    return request.delete(`/user/plan/${planId}`)
+  },
+
+  // 获取计划详情
+  getPlanDetail(planId) {
+    return request.get(`/user/plan/${planId}`)
+  },
+
+  // 获取计划列表
+  getPlanList(data) {
+    return request.post('/user/plan/list', data)
+  },
+
+  // 暂停计划
+  pausePlan(planId) {
+    return request.put(`/user/plan/${planId}/pause`)
+  },
+
+  // 恢复计划
+  resumePlan(planId) {
+    return request.put(`/user/plan/${planId}/resume`)
+  },
+
+  // 获取今日任务
+  getTodayTasks() {
+    return request.get('/user/plan/today-tasks')
+  },
+
+  // 执行打卡
+  checkin(data) {
+    return request.post('/user/plan/checkin', data)
+  },
+
+  // 获取打卡记录
+  getCheckinRecords(planId) {
+    return request.get(`/user/plan/${planId}/checkin/list`)
+  },
+
+  // 获取统计概览
+  getStatsOverview() {
+    return request.get('/user/plan/stats/overview')
+  }
+}
+
+export default planApi

--- a/vue3-user-front/src/router/index.js
+++ b/vue3-user-front/src/router/index.js
@@ -251,6 +251,16 @@ const routes = [
     }
   },
   {
+    path: '/plan',
+    name: 'PlanCheckin',
+    component: () => import('@/views/plan/Index.vue'),
+    meta: {
+      title: '计划打卡',
+      requiresAuth: true,
+      keepAlive: true
+    }
+  },
+  {
     path: '/lottery',
     name: 'Lottery',
     component: () => import('@/views/lottery/index.vue'),

--- a/vue3-user-front/src/views/Home.vue
+++ b/vue3-user-front/src/views/Home.vue
@@ -149,7 +149,7 @@ import { ref } from 'vue'
 import { 
   Reading, ChatDotRound, ArrowRight, Document, Edit, 
   Monitor, Share, Bell, Trophy, Cpu, Connection,
-  Compass, Coffee, TrendCharts, Ticket, ChatLineSquare, DataAnalysis
+  Compass, Coffee, TrendCharts, Ticket, ChatLineSquare, DataAnalysis, Calendar
 } from '@element-plus/icons-vue'
 
 // 核心功能数据
@@ -203,6 +203,7 @@ const quickAccess = ref([
   { title: '朋友圈', icon: 'ChatLineSquare', path: '/moments', color: 'linear-gradient(135deg, #667eea, #764ba2)' },
   { title: '聊天室', icon: 'ChatDotRound', path: '/chat', color: 'linear-gradient(135deg, #f093fb, #f5576c)' },
   { title: '通知中心', icon: 'Bell', path: '/notification', color: 'linear-gradient(135deg, #4facfe, #00f2fe)' },
+  { title: '计划打卡', icon: 'Calendar', path: '/plan', color: 'linear-gradient(135deg, #f5af19, #f12711)' },
   { title: '我的积分', icon: 'Trophy', path: '/points', color: 'linear-gradient(135deg, #43e97b, #38f9d7)' },
   { title: '幸运抽奖', icon: 'Ticket', path: '/lottery', color: 'linear-gradient(135deg, #fa709a, #fee140)' },
   { title: '摸鱼工具', icon: 'Coffee', path: '/moyu-tools', color: 'linear-gradient(135deg, #a18cd1, #fbc2eb)' },

--- a/vue3-user-front/src/views/Home.vue
+++ b/vue3-user-front/src/views/Home.vue
@@ -1,66 +1,690 @@
 <template>
   <div class="home-container">
-    <!-- 欢迎区域 -->
-    <div class="welcome-section">
-      <div class="welcome-content">
-        <h1 class="welcome-title">欢迎来到 Code Nest</h1>
+    <!-- Hero 区域 -->
+    <section class="hero-section">
+      <div class="hero-bg">
+        <div class="floating-shapes">
+          <div class="shape shape-1"></div>
+          <div class="shape shape-2"></div>
+          <div class="shape shape-3"></div>
+          <div class="shape shape-4"></div>
+          <div class="shape shape-5"></div>
+        </div>
       </div>
-    </div>
+      <div class="hero-content">
+        <div class="hero-badge">🚀 开发者成长社区</div>
+        <h1 class="hero-title">
+          <span class="gradient-text">Code Nest</span>
+          <br />
+          <span class="sub-title">程序员的技术成长乐园</span>
+        </h1>
+        <p class="hero-desc">
+          集面试刷题、知识图谱、在线简历、代码工坊、技术博客、社区互动于一体的一站式开发者平台
+        </p>
+        <div class="hero-actions">
+          <el-button type="primary" size="large" class="action-btn primary-btn" @click="$router.push('/interview')">
+            <el-icon><Reading /></el-icon>
+            开始刷题
+          </el-button>
+          <el-button size="large" class="action-btn secondary-btn" @click="$router.push('/community')">
+            <el-icon><ChatDotRound /></el-icon>
+            进入社区
+          </el-button>
+        </div>
+        <div class="hero-stats">
+          <div class="stat-item">
+            <span class="stat-number">1000+</span>
+            <span class="stat-label">面试题目</span>
+          </div>
+          <div class="stat-divider"></div>
+          <div class="stat-item">
+            <span class="stat-number">50+</span>
+            <span class="stat-label">知识图谱</span>
+          </div>
+          <div class="stat-divider"></div>
+          <div class="stat-item">
+            <span class="stat-number">10+</span>
+            <span class="stat-label">实用工具</span>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <!-- 核心功能区域 -->
+    <section class="features-section">
+      <div class="section-header">
+        <h2 class="section-title">核心功能</h2>
+        <p class="section-subtitle">全方位助力你的技术成长之路</p>
+      </div>
+      <div class="features-grid">
+        <div 
+          v-for="(feature, index) in features" 
+          :key="feature.title" 
+          class="feature-card"
+          :style="{ animationDelay: `${index * 0.1}s` }"
+          @click="$router.push(feature.path)"
+        >
+          <div class="feature-icon" :style="{ background: feature.gradient }">
+            <el-icon :size="28"><component :is="feature.icon" /></el-icon>
+          </div>
+          <h3 class="feature-title">{{ feature.title }}</h3>
+          <p class="feature-desc">{{ feature.desc }}</p>
+          <div class="feature-arrow">
+            <el-icon><ArrowRight /></el-icon>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <!-- 快速入口区域 -->
+    <section class="quick-access-section">
+      <div class="section-header">
+        <h2 class="section-title">快速入口</h2>
+        <p class="section-subtitle">一键直达常用功能</p>
+      </div>
+      <div class="quick-access-grid">
+        <div 
+          v-for="item in quickAccess" 
+          :key="item.title" 
+          class="quick-item"
+          @click="$router.push(item.path)"
+        >
+          <div class="quick-icon" :style="{ background: item.color }">
+            <el-icon :size="24"><component :is="item.icon" /></el-icon>
+          </div>
+          <span class="quick-title">{{ item.title }}</span>
+        </div>
+      </div>
+    </section>
+
+    <!-- 特色亮点区域 -->
+    <section class="highlights-section">
+      <div class="highlights-content">
+        <div class="highlight-item">
+          <div class="highlight-icon">
+            <el-icon :size="32"><Cpu /></el-icon>
+          </div>
+          <div class="highlight-info">
+            <h3>智能学习系统</h3>
+            <p>基于知识图谱的学习路径规划，助你高效提升技术能力</p>
+          </div>
+        </div>
+        <div class="highlight-item">
+          <div class="highlight-icon">
+            <el-icon :size="32"><Trophy /></el-icon>
+          </div>
+          <div class="highlight-info">
+            <h3>积分激励体系</h3>
+            <p>完成任务获取积分，参与抽奖赢取丰厚奖品</p>
+          </div>
+        </div>
+        <div class="highlight-item">
+          <div class="highlight-icon">
+            <el-icon :size="32"><Connection /></el-icon>
+          </div>
+          <div class="highlight-info">
+            <h3>实时互动社区</h3>
+            <p>技术讨论、在线聊天、动态分享，与志同道合的开发者交流</p>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <!-- 底部 CTA -->
+    <section class="cta-section">
+      <div class="cta-content">
+        <h2>准备好开始你的技术成长之旅了吗？</h2>
+        <p>加入 Code Nest，与万千开发者一起学习进步</p>
+        <el-button type="primary" size="large" class="cta-btn" @click="$router.push('/interview')">
+          立即开始
+          <el-icon class="el-icon--right"><ArrowRight /></el-icon>
+        </el-button>
+      </div>
+    </section>
   </div>
 </template>
 
 <script setup>
-// 简化的首页不需要复杂的逻辑
+import { ref } from 'vue'
+import { 
+  Reading, ChatDotRound, ArrowRight, Document, Edit, 
+  Monitor, Share, Bell, Trophy, Cpu, Connection,
+  Compass, Coffee, TrendCharts, Ticket, ChatLineSquare, DataAnalysis
+} from '@element-plus/icons-vue'
+
+// 核心功能数据
+const features = ref([
+  {
+    title: '面试题库',
+    desc: '海量面试真题，覆盖前端、后端、算法等热门方向，助你斩获心仪 Offer',
+    icon: 'Reading',
+    path: '/interview',
+    gradient: 'linear-gradient(135deg, #667eea 0%, #764ba2 100%)'
+  },
+  {
+    title: '知识图谱',
+    desc: '可视化知识体系，理清技术脉络，构建完整的技术知识网络',
+    icon: 'Share',
+    path: '/knowledge',
+    gradient: 'linear-gradient(135deg, #f093fb 0%, #f5576c 100%)'
+  },
+  {
+    title: '在线简历',
+    desc: '专业简历模板，在线编辑导出，让你的简历脱颖而出',
+    icon: 'Document',
+    path: '/resume',
+    gradient: 'linear-gradient(135deg, #4facfe 0%, #00f2fe 100%)'
+  },
+  {
+    title: '代码工坊',
+    desc: '在线代码编辑器，支持多种语言，实时预览与分享你的创意',
+    icon: 'Monitor',
+    path: '/codepen',
+    gradient: 'linear-gradient(135deg, #43e97b 0%, #38f9d7 100%)'
+  },
+  {
+    title: '技术博客',
+    desc: 'Markdown 写作，记录学习心得，分享技术经验',
+    icon: 'Edit',
+    path: '/blog',
+    gradient: 'linear-gradient(135deg, #fa709a 0%, #fee140 100%)'
+  },
+  {
+    title: '技术社区',
+    desc: '问答交流、技术讨论，与全国开发者一起探讨技术难题',
+    icon: 'ChatDotRound',
+    path: '/community',
+    gradient: 'linear-gradient(135deg, #a18cd1 0%, #fbc2eb 100%)'
+  }
+])
+
+// 快速入口数据
+const quickAccess = ref([
+  { title: '朋友圈', icon: 'ChatLineSquare', path: '/moments', color: 'linear-gradient(135deg, #667eea, #764ba2)' },
+  { title: '聊天室', icon: 'ChatDotRound', path: '/chat', color: 'linear-gradient(135deg, #f093fb, #f5576c)' },
+  { title: '通知中心', icon: 'Bell', path: '/notification', color: 'linear-gradient(135deg, #4facfe, #00f2fe)' },
+  { title: '我的积分', icon: 'Trophy', path: '/points', color: 'linear-gradient(135deg, #43e97b, #38f9d7)' },
+  { title: '幸运抽奖', icon: 'Ticket', path: '/lottery', color: 'linear-gradient(135deg, #fa709a, #fee140)' },
+  { title: '摸鱼工具', icon: 'Coffee', path: '/moyu-tools', color: 'linear-gradient(135deg, #a18cd1, #fbc2eb)' },
+  { title: '开发工具', icon: 'Compass', path: '/dev-tools', color: 'linear-gradient(135deg, #ff9a9e, #fecfef)' },
+  { title: '版本历史', icon: 'DataAnalysis', path: '/version-history', color: 'linear-gradient(135deg, #89f7fe, #66a6ff)' }
+])
 </script>
 
 <style scoped>
 .home-container {
   min-height: 100vh;
+  background: #f5f7fa;
+  overflow-x: hidden;
+}
+
+/* Hero 区域 */
+.hero-section {
+  position: relative;
+  min-height: 100vh;
   display: flex;
   align-items: center;
   justify-content: center;
-  background: linear-gradient(135deg, #1890ff 0%, #096dd9 100%);
-  position: relative;
+  padding: 60px 20px;
   overflow: hidden;
 }
 
-.home-container::before {
-  content: '';
+.hero-bg {
   position: absolute;
   top: 0;
   left: 0;
   right: 0;
   bottom: 0;
-  background: 
-    radial-gradient(circle at 20% 50%, rgba(255, 255, 255, 0.1) 0%, transparent 50%),
-    radial-gradient(circle at 80% 20%, rgba(255, 255, 255, 0.1) 0%, transparent 50%),
-    radial-gradient(circle at 40% 80%, rgba(255, 255, 255, 0.1) 0%, transparent 50%);
+  background: linear-gradient(135deg, #1a1a2e 0%, #16213e 50%, #0f3460 100%);
 }
 
-.welcome-section {
+.floating-shapes {
+  position: absolute;
+  width: 100%;
+  height: 100%;
+  overflow: hidden;
+}
+
+.shape {
+  position: absolute;
+  border-radius: 50%;
+  background: linear-gradient(135deg, rgba(102, 126, 234, 0.3), rgba(118, 75, 162, 0.3));
+  animation: float 15s infinite ease-in-out;
+}
+
+.shape-1 {
+  width: 400px;
+  height: 400px;
+  top: -100px;
+  left: -100px;
+  animation-delay: 0s;
+}
+
+.shape-2 {
+  width: 300px;
+  height: 300px;
+  top: 50%;
+  right: -50px;
+  background: linear-gradient(135deg, rgba(79, 172, 254, 0.3), rgba(0, 242, 254, 0.3));
+  animation-delay: -5s;
+}
+
+.shape-3 {
+  width: 200px;
+  height: 200px;
+  bottom: 10%;
+  left: 10%;
+  background: linear-gradient(135deg, rgba(250, 112, 154, 0.3), rgba(254, 225, 64, 0.3));
+  animation-delay: -10s;
+}
+
+.shape-4 {
+  width: 150px;
+  height: 150px;
+  top: 20%;
+  right: 20%;
+  background: linear-gradient(135deg, rgba(67, 233, 123, 0.3), rgba(56, 249, 215, 0.3));
+  animation-delay: -7s;
+}
+
+.shape-5 {
+  width: 250px;
+  height: 250px;
+  bottom: -50px;
+  right: 30%;
+  background: linear-gradient(135deg, rgba(161, 140, 209, 0.3), rgba(251, 194, 235, 0.3));
+  animation-delay: -12s;
+}
+
+@keyframes float {
+  0%, 100% {
+    transform: translate(0, 0) rotate(0deg);
+  }
+  25% {
+    transform: translate(30px, -30px) rotate(5deg);
+  }
+  50% {
+    transform: translate(-20px, 20px) rotate(-5deg);
+  }
+  75% {
+    transform: translate(20px, 10px) rotate(3deg);
+  }
+}
+
+.hero-content {
   position: relative;
   z-index: 10;
   text-align: center;
-}
-
-.welcome-content {
+  max-width: 800px;
   animation: fadeInUp 1s ease-out;
 }
 
-.welcome-title {
-  font-size: 64px;
-  font-weight: bold;
-  color: white;
-  margin: 0;
-  text-shadow: 0 4px 16px rgba(0, 0, 0, 0.3);
+.hero-badge {
+  display: inline-block;
+  padding: 8px 20px;
+  background: rgba(255, 255, 255, 0.1);
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  border-radius: 50px;
+  color: #a5b4fc;
+  font-size: 14px;
+  margin-bottom: 24px;
+  backdrop-filter: blur(10px);
+}
+
+.hero-title {
+  margin: 0 0 24px;
+  line-height: 1.2;
+}
+
+.gradient-text {
+  font-size: 72px;
+  font-weight: 800;
+  background: linear-gradient(135deg, #667eea 0%, #764ba2 30%, #f093fb 60%, #4facfe 100%);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-clip: text;
+  letter-spacing: -2px;
+}
+
+.sub-title {
+  font-size: 28px;
+  color: rgba(255, 255, 255, 0.9);
+  font-weight: 400;
   letter-spacing: 2px;
 }
 
-/* 动画定义 */
+.hero-desc {
+  font-size: 18px;
+  color: rgba(255, 255, 255, 0.7);
+  line-height: 1.8;
+  margin-bottom: 40px;
+  max-width: 600px;
+  margin-left: auto;
+  margin-right: auto;
+}
+
+.hero-actions {
+  display: flex;
+  gap: 16px;
+  justify-content: center;
+  margin-bottom: 60px;
+}
+
+.action-btn {
+  padding: 14px 32px;
+  font-size: 16px;
+  border-radius: 12px;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.primary-btn {
+  background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+  border: none;
+  box-shadow: 0 8px 30px rgba(102, 126, 234, 0.4);
+}
+
+.primary-btn:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 12px 40px rgba(102, 126, 234, 0.5);
+}
+
+.secondary-btn {
+  background: rgba(255, 255, 255, 0.1);
+  border: 1px solid rgba(255, 255, 255, 0.3);
+  color: white;
+  backdrop-filter: blur(10px);
+}
+
+.secondary-btn:hover {
+  background: rgba(255, 255, 255, 0.2);
+  color: white;
+}
+
+.hero-stats {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 40px;
+}
+
+.stat-item {
+  text-align: center;
+}
+
+.stat-number {
+  display: block;
+  font-size: 36px;
+  font-weight: 700;
+  color: white;
+  line-height: 1.2;
+}
+
+.stat-label {
+  font-size: 14px;
+  color: rgba(255, 255, 255, 0.6);
+}
+
+.stat-divider {
+  width: 1px;
+  height: 40px;
+  background: rgba(255, 255, 255, 0.2);
+}
+
+/* 功能区域 */
+.features-section {
+  padding: 100px 20px;
+  max-width: 1200px;
+  margin: 0 auto;
+}
+
+.section-header {
+  text-align: center;
+  margin-bottom: 60px;
+}
+
+.section-title {
+  font-size: 36px;
+  font-weight: 700;
+  color: #1a1a2e;
+  margin: 0 0 16px;
+}
+
+.section-subtitle {
+  font-size: 16px;
+  color: #6b7280;
+  margin: 0;
+}
+
+.features-grid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 30px;
+}
+
+.feature-card {
+  background: white;
+  border-radius: 20px;
+  padding: 32px;
+  cursor: pointer;
+  transition: all 0.3s ease;
+  position: relative;
+  overflow: hidden;
+  animation: fadeInUp 0.6s ease-out both;
+}
+
+.feature-card::before {
+  content: '';
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  height: 4px;
+  background: linear-gradient(90deg, #667eea, #764ba2);
+  opacity: 0;
+  transition: opacity 0.3s ease;
+}
+
+.feature-card:hover {
+  transform: translateY(-8px);
+  box-shadow: 0 20px 60px rgba(0, 0, 0, 0.1);
+}
+
+.feature-card:hover::before {
+  opacity: 1;
+}
+
+.feature-icon {
+  width: 60px;
+  height: 60px;
+  border-radius: 16px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: white;
+  margin-bottom: 20px;
+}
+
+.feature-title {
+  font-size: 20px;
+  font-weight: 600;
+  color: #1a1a2e;
+  margin: 0 0 12px;
+}
+
+.feature-desc {
+  font-size: 14px;
+  color: #6b7280;
+  line-height: 1.6;
+  margin: 0;
+}
+
+.feature-arrow {
+  position: absolute;
+  right: 24px;
+  bottom: 24px;
+  width: 36px;
+  height: 36px;
+  border-radius: 50%;
+  background: #f3f4f6;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: #6b7280;
+  transition: all 0.3s ease;
+}
+
+.feature-card:hover .feature-arrow {
+  background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+  color: white;
+  transform: translateX(4px);
+}
+
+/* 快速入口区域 */
+.quick-access-section {
+  padding: 80px 20px;
+  background: white;
+}
+
+.quick-access-grid {
+  display: grid;
+  grid-template-columns: repeat(8, 1fr);
+  gap: 20px;
+  max-width: 1200px;
+  margin: 0 auto;
+}
+
+.quick-item {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 12px;
+  padding: 24px 16px;
+  border-radius: 16px;
+  cursor: pointer;
+  transition: all 0.3s ease;
+}
+
+.quick-item:hover {
+  background: #f8fafc;
+  transform: translateY(-4px);
+}
+
+.quick-icon {
+  width: 56px;
+  height: 56px;
+  border-radius: 16px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: white;
+  transition: transform 0.3s ease;
+}
+
+.quick-item:hover .quick-icon {
+  transform: scale(1.1);
+}
+
+.quick-title {
+  font-size: 14px;
+  color: #374151;
+  font-weight: 500;
+}
+
+/* 亮点区域 */
+.highlights-section {
+  padding: 80px 20px;
+  background: linear-gradient(135deg, #f8fafc 0%, #e2e8f0 100%);
+}
+
+.highlights-content {
+  max-width: 1200px;
+  margin: 0 auto;
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 40px;
+}
+
+.highlight-item {
+  display: flex;
+  gap: 20px;
+  padding: 32px;
+  background: white;
+  border-radius: 20px;
+  transition: all 0.3s ease;
+}
+
+.highlight-item:hover {
+  transform: translateY(-4px);
+  box-shadow: 0 10px 40px rgba(0, 0, 0, 0.08);
+}
+
+.highlight-icon {
+  width: 64px;
+  height: 64px;
+  border-radius: 16px;
+  background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: white;
+  flex-shrink: 0;
+}
+
+.highlight-info h3 {
+  font-size: 18px;
+  font-weight: 600;
+  color: #1a1a2e;
+  margin: 0 0 8px;
+}
+
+.highlight-info p {
+  font-size: 14px;
+  color: #6b7280;
+  line-height: 1.6;
+  margin: 0;
+}
+
+/* CTA 区域 */
+.cta-section {
+  padding: 100px 20px;
+  background: linear-gradient(135deg, #1a1a2e 0%, #16213e 100%);
+  text-align: center;
+}
+
+.cta-content h2 {
+  font-size: 36px;
+  font-weight: 700;
+  color: white;
+  margin: 0 0 16px;
+}
+
+.cta-content p {
+  font-size: 18px;
+  color: rgba(255, 255, 255, 0.7);
+  margin: 0 0 40px;
+}
+
+.cta-btn {
+  padding: 16px 40px;
+  font-size: 18px;
+  border-radius: 12px;
+  background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+  border: none;
+  box-shadow: 0 8px 30px rgba(102, 126, 234, 0.4);
+}
+
+.cta-btn:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 12px 40px rgba(102, 126, 234, 0.5);
+}
+
+/* 动画 */
 @keyframes fadeInUp {
   from {
     opacity: 0;
-    transform: translateY(50px);
+    transform: translateY(30px);
   }
   to {
     opacity: 1;
@@ -68,18 +692,73 @@
   }
 }
 
-/* 响应式设计 */
+/* 响应式 */
+@media (max-width: 1024px) {
+  .features-grid {
+    grid-template-columns: repeat(2, 1fr);
+  }
+  
+  .quick-access-grid {
+    grid-template-columns: repeat(4, 1fr);
+  }
+  
+  .highlights-content {
+    grid-template-columns: 1fr;
+  }
+}
+
 @media (max-width: 768px) {
-  .welcome-title {
+  .gradient-text {
     font-size: 48px;
-    letter-spacing: 1px;
+  }
+  
+  .sub-title {
+    font-size: 20px;
+  }
+  
+  .hero-desc {
+    font-size: 16px;
+  }
+  
+  .hero-actions {
+    flex-direction: column;
+    align-items: center;
+  }
+  
+  .hero-stats {
+    flex-wrap: wrap;
+    gap: 24px;
+  }
+  
+  .stat-divider {
+    display: none;
+  }
+  
+  .features-grid {
+    grid-template-columns: 1fr;
+  }
+  
+  .quick-access-grid {
+    grid-template-columns: repeat(4, 1fr);
+    gap: 12px;
+  }
+  
+  .section-title {
+    font-size: 28px;
+  }
+  
+  .cta-content h2 {
+    font-size: 28px;
   }
 }
 
 @media (max-width: 480px) {
-  .welcome-title {
+  .gradient-text {
     font-size: 36px;
-    letter-spacing: 0.5px;
+  }
+  
+  .quick-access-grid {
+    grid-template-columns: repeat(3, 1fr);
   }
 }
-</style> 
+</style>

--- a/vue3-user-front/src/views/interview/QuestionDetail.vue
+++ b/vue3-user-front/src/views/interview/QuestionDetail.vue
@@ -95,7 +95,9 @@
     <div class="bottom-nav">
       <el-card shadow="never" class="nav-card">
         <div class="nav-content">
+          <!-- 桌面端按钮 -->
           <el-button 
+            class="desktop-nav-btn"
             @click="goToPrevQuestion" 
             :disabled="!hasPrev"
             :icon="ArrowLeft"
@@ -104,20 +106,43 @@
           </el-button>
           
           <div class="progress-info">
-            <span>{{ currentIndex + 1 }} / {{ totalQuestions }}</span>
+            <span class="progress-text">{{ currentIndex + 1 }} / {{ totalQuestions }}</span>
             <el-progress 
               :percentage="progressPercentage" 
               :stroke-width="8"
-              style="width: 200px; margin: 0 20px;"
+              :show-text="false"
             />
           </div>
           
+          <!-- 桌面端按钮 -->
           <el-button 
+            class="desktop-nav-btn"
             @click="goToNextQuestion" 
             :disabled="!hasNext"
-            :icon="ArrowRight"
           >
             下一题
+            <el-icon class="el-icon--right"><ArrowRight /></el-icon>
+          </el-button>
+        </div>
+        
+        <!-- 手机端专用按钮组 -->
+        <div class="mobile-nav-buttons">
+          <el-button 
+            @click="goToPrevQuestion" 
+            :disabled="!hasPrev"
+            :icon="ArrowLeft"
+            size="large"
+          >
+            上一题
+          </el-button>
+          <el-button 
+            type="primary"
+            @click="goToNextQuestion" 
+            :disabled="!hasNext"
+            size="large"
+          >
+            下一题
+            <el-icon class="el-icon--right"><ArrowRight /></el-icon>
           </el-button>
         </div>
       </el-card>
@@ -323,39 +348,58 @@ onMounted(() => {
 <style scoped>
 .question-detail {
   min-height: 100vh;
-  background: linear-gradient(135deg, #f5f7fa 0%, #c3cfe2 100%);
+  background: #f5f7fa;
   display: flex;
   flex-direction: column;
 }
 
+/* 顶部导航栏 */
 .nav-bar {
-  background: rgba(255, 255, 255, 0.95);
-  backdrop-filter: blur(10px);
-  border-bottom: 1px solid #e4e7ed;
-  padding: 12px 20px;
+  background: rgba(255, 255, 255, 0.98);
+  backdrop-filter: blur(20px);
+  -webkit-backdrop-filter: blur(20px);
+  border-bottom: 1px solid rgba(0, 0, 0, 0.06);
+  padding: 16px 24px;
   display: flex;
   justify-content: space-between;
   align-items: center;
   position: sticky;
   top: 0;
   z-index: 100;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.04);
 }
 
 .nav-left {
   display: flex;
   align-items: center;
-  gap: 12px;
+  gap: 16px;
+  flex: 1;
+  min-width: 0;
+}
+
+.nav-left :deep(.el-button) {
+  font-weight: 500;
+  color: #409eff;
+}
+
+.nav-left :deep(.el-button:hover) {
+  color: #337ecc;
 }
 
 .breadcrumb {
   color: #606266;
   font-size: 14px;
+  font-weight: 500;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 .nav-right {
   display: flex;
   align-items: center;
-  gap: 12px;
+  gap: 16px;
+  flex-shrink: 0;
 }
 
 .mode-toggle {
@@ -363,46 +407,87 @@ onMounted(() => {
   align-items: center;
 }
 
+.mode-toggle :deep(.el-switch) {
+  --el-switch-on-color: #409eff;
+}
+
+/* 题目内容区域 */
 .question-content-wrapper {
   flex: 1;
-  padding: 20px;
+  padding: 24px;
   overflow-y: auto;
 }
 
 .question-card {
-  max-width: 900px;
+  max-width: 1000px;
+  width: 65%;
+  min-width: 600px;
   margin: 0 auto;
-  background: rgba(255, 255, 255, 0.95);
+  background: #ffffff;
   border: none;
+  border-radius: 16px;
+  box-shadow: 0 4px 20px rgba(0, 0, 0, 0.08);
+  overflow: hidden;
+}
+
+.question-card :deep(.el-card__body) {
+  padding: 32px;
 }
 
 .question-header {
-  border-bottom: 1px solid #f0f2f5;
-  padding-bottom: 20px;
-  margin-bottom: 30px;
+  border-bottom: 2px solid #f0f2f5;
+  padding-bottom: 24px;
+  margin-bottom: 32px;
+  position: relative;
+}
+
+.question-header::after {
+  content: '';
+  position: absolute;
+  bottom: -2px;
+  left: 0;
+  width: 60px;
+  height: 2px;
+  background: #409eff;
+  border-radius: 2px;
 }
 
 .question-title {
-  margin: 0 0 12px 0;
-  color: #303133;
-  font-size: 28px;
-  font-weight: bold;
-  line-height: 1.4;
+  margin: 0 0 16px 0;
+  color: #1a1a2e;
+  font-size: 26px;
+  font-weight: 700;
+  line-height: 1.5;
+  letter-spacing: -0.5px;
 }
 
 .question-meta {
   display: flex;
-  gap: 20px;
-  color: #909399;
+  gap: 24px;
+  color: #8c8c8c;
   font-size: 14px;
 }
 
 .question-meta span {
   display: flex;
   align-items: center;
-  gap: 4px;
+  gap: 6px;
+  padding: 6px 12px;
+  background: #f5f7fa;
+  border-radius: 20px;
+  transition: all 0.3s ease;
 }
 
+.question-meta span:hover {
+  background: #ecf5ff;
+  color: #409eff;
+}
+
+.question-meta :deep(.el-icon) {
+  font-size: 16px;
+}
+
+/* 题目内容 */
 .question-content {
   line-height: 1.8;
 }
@@ -412,45 +497,135 @@ onMounted(() => {
 }
 
 .answer-section h3 {
-  margin: 0 0 16px 0;
-  color: #303133;
-  font-size: 20px;
+  margin: 0 0 20px 0;
+  color: #1a1a2e;
+  font-size: 18px;
   font-weight: 600;
+  display: flex;
+  align-items: center;
+  gap: 8px;
 }
 
-.answer-content {
-  background: rgba(240, 249, 255, 0.5);
-  border: 2px solid #409EFF;
-  border-radius: 12px;
+.answer-section h3::before {
+  content: '';
+  display: inline-block;
+  width: 4px;
+  height: 20px;
+  background: #409eff;
+  border-radius: 2px;
+}
+
+.markdown-content {
+  background: linear-gradient(135deg, #f8fafc 0%, #f1f5f9 100%);
+  border-radius: 16px;
   padding: 24px;
-  margin-top: 16px;
+  border: 1px solid #e2e8f0;
+}
+
+.markdown-content :deep(pre) {
+  background: #1e293b;
+  border-radius: 12px;
+  padding: 16px;
+  overflow-x: auto;
+}
+
+.markdown-content :deep(code) {
+  font-family: 'Fira Code', 'JetBrains Mono', monospace;
+  font-size: 14px;
+}
+
+.markdown-content :deep(p) {
+  margin-bottom: 16px;
+  color: #334155;
+}
+
+.markdown-content :deep(ul), 
+.markdown-content :deep(ol) {
+  padding-left: 24px;
+  margin-bottom: 16px;
+}
+
+.markdown-content :deep(li) {
+  margin-bottom: 8px;
+  color: #475569;
+}
+
+.markdown-content :deep(h1),
+.markdown-content :deep(h2),
+.markdown-content :deep(h3),
+.markdown-content :deep(h4) {
+  color: #1e293b;
+  margin-top: 24px;
+  margin-bottom: 12px;
+}
+
+.markdown-content :deep(blockquote) {
+  border-left: 4px solid #409eff;
+  padding-left: 16px;
+  margin: 16px 0;
+  color: #64748b;
+  background: #f8fafc;
+  padding: 12px 16px;
+  border-radius: 0 8px 8px 0;
 }
 
 .action-buttons {
-  margin-top: 30px;
+  margin-top: 32px;
   text-align: center;
+}
+
+.action-buttons :deep(.el-button) {
+  padding: 12px 32px;
+  font-size: 15px;
+  border-radius: 12px;
+  font-weight: 500;
+  transition: all 0.3s ease;
+}
+
+.action-buttons :deep(.el-button--primary) {
+  background: #409eff;
+  border: none;
+}
+
+.action-buttons :deep(.el-button--primary:hover) {
+  background: #337ecc;
 }
 
 .mode-tip {
   margin-top: 24px;
 }
 
+.mode-tip :deep(.el-alert) {
+  border-radius: 12px;
+  border: none;
+  background: linear-gradient(135deg, #ecfdf5 0%, #d1fae5 100%);
+}
+
+/* 底部导航 */
 .bottom-nav {
-  background: rgba(255, 255, 255, 0.95);
-  backdrop-filter: blur(10px);
-  border-top: 1px solid #e4e7ed;
-  padding: 16px 20px;
+  background: rgba(255, 255, 255, 0.98);
+  backdrop-filter: blur(20px);
+  -webkit-backdrop-filter: blur(20px);
+  border-top: 1px solid rgba(0, 0, 0, 0.06);
+  padding: 16px 24px;
   position: sticky;
   bottom: 0;
   z-index: 100;
+  box-shadow: 0 -4px 20px rgba(0, 0, 0, 0.06);
 }
 
 .nav-card {
-  max-width: 900px;
+  max-width: 1000px;
+  width: 65%;
+  min-width: 600px;
   margin: 0 auto;
   background: transparent;
   border: none;
   box-shadow: none;
+}
+
+.nav-card :deep(.el-card__body) {
+  padding: 0;
 }
 
 .nav-content {
@@ -459,71 +634,371 @@ onMounted(() => {
   align-items: center;
 }
 
+.nav-content :deep(.el-button) {
+  border-radius: 10px;
+  font-weight: 500;
+  padding: 10px 20px;
+  transition: all 0.3s ease;
+}
+
+.nav-content :deep(.el-button:not(.is-disabled):hover) {
+  transform: translateX(-3px);
+}
+
+.nav-content :deep(.el-button:last-child:not(.is-disabled):hover) {
+  transform: translateX(3px);
+}
+
 .progress-info {
   display: flex;
   align-items: center;
-  gap: 12px;
+  gap: 16px;
   font-weight: 600;
-  color: #303133;
+  color: #1a1a2e;
+  font-size: 15px;
 }
 
-@media (max-width: 768px) {
-  .question-detail {
-    padding: 0;
+.progress-info :deep(.el-progress) {
+  width: 200px;
+}
+
+.progress-info :deep(.el-progress-bar__outer) {
+  background: #e2e8f0;
+}
+
+.progress-info :deep(.el-progress-bar__inner) {
+  background: #409eff;
+}
+
+/* ===== 平板端适配 (768px - 1024px) ===== */
+@media (max-width: 1024px) and (min-width: 769px) {
+  .nav-bar {
+    padding: 14px 20px;
   }
   
+  .question-content-wrapper {
+    padding: 20px;
+  }
+  
+  .question-card :deep(.el-card__body) {
+    padding: 28px;
+  }
+  
+  .question-title {
+    font-size: 24px;
+  }
+  
+  .progress-info :deep(.el-progress) {
+    width: 160px;
+  }
+}
+
+/* ===== 手机端适配 (小于等于768px) ===== */
+@media (max-width: 768px) {
+  .question-detail {
+    background: #f5f7fa;
+  }
+  
+  /* 顶部导航 - 手机端 */
   .nav-bar {
-    padding: 8px 12px;
+    padding: 12px 16px;
     flex-direction: column;
-    align-items: flex-start;
-    gap: 8px;
+    align-items: stretch;
+    gap: 12px;
   }
   
   .nav-left {
     width: 100%;
+    justify-content: flex-start;
+  }
+  
+  .nav-left :deep(.el-divider) {
+    display: none;
+  }
+  
+  .breadcrumb {
+    font-size: 13px;
+    max-width: 200px;
   }
   
   .nav-right {
-    align-self: flex-end;
-    flex-wrap: wrap;
-    gap: 8px;
+    width: 100%;
+    justify-content: space-between;
+    padding-top: 8px;
+    border-top: 1px solid #f0f2f5;
   }
   
   .mode-toggle {
-    order: -1;
+    flex: 1;
+  }
+  
+  .mode-toggle :deep(.el-switch__label) {
+    font-size: 12px;
+  }
+  
+  /* 内容区域 - 手机端 */
+  .question-content-wrapper {
+    padding: 16px 12px;
+  }
+  
+  .question-card {
     width: 100%;
-    margin-bottom: 8px;
+    min-width: unset;
+    border-radius: 12px;
+    box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+  }
+  
+  .question-card :deep(.el-card__body) {
+    padding: 20px;
+  }
+  
+  .question-header {
+    padding-bottom: 16px;
+    margin-bottom: 20px;
+  }
+  
+  .question-title {
+    font-size: 20px;
+    line-height: 1.4;
+  }
+  
+  .question-meta {
+    flex-wrap: wrap;
+    gap: 10px;
+  }
+  
+  .question-meta span {
+    padding: 4px 10px;
+    font-size: 13px;
+  }
+  
+  .answer-section h3 {
+    font-size: 16px;
+  }
+  
+  .markdown-content {
+    padding: 16px;
+    font-size: 14px;
+    border-radius: 12px;
+  }
+  
+  .markdown-content :deep(pre) {
+    padding: 12px;
+    font-size: 12px;
+    border-radius: 8px;
+  }
+  
+  .markdown-content :deep(code) {
+    font-size: 12px;
+  }
+  
+  .action-buttons :deep(.el-button) {
+    width: 100%;
+    padding: 14px 24px;
+  }
+  
+  /* 底部导航 - 手机端 */
+  .bottom-nav {
+    padding: 12px 16px;
+  }
+  
+  .nav-content {
+    justify-content: center;
+  }
+  
+  .progress-info {
+    width: 100%;
+    justify-content: center;
+  }
+  
+  .progress-info :deep(.el-progress) {
+    flex: 1;
+    max-width: 200px;
+  }
+}
+
+/* ===== 小屏手机适配 (小于等于480px) ===== */
+@media (max-width: 480px) {
+  .nav-bar {
+    padding: 10px 12px;
+  }
+  
+  .nav-left :deep(.el-button span) {
+    display: none;
+  }
+  
+  .breadcrumb {
+    font-size: 12px;
+    max-width: 150px;
+  }
+  
+  .question-content-wrapper {
+    padding: 12px 8px;
+  }
+  
+  .question-card :deep(.el-card__body) {
+    padding: 16px;
+  }
+  
+  .question-title {
+    font-size: 18px;
+  }
+  
+  .question-meta {
+    gap: 8px;
+  }
+  
+  .question-meta span {
+    padding: 3px 8px;
+    font-size: 12px;
+  }
+  
+  .markdown-content {
+    padding: 12px;
+  }
+  
+  .markdown-content :deep(pre) {
+    padding: 10px;
+    margin: 12px -12px;
+    border-radius: 0;
+  }
+  
+  .bottom-nav {
+    padding: 10px 12px;
+  }
+  
+  .progress-info {
+    font-size: 14px;
+    gap: 10px;
+  }
+  
+  .progress-info :deep(.el-progress) {
+    max-width: 150px;
+  }
+}
+
+/* 桌面端导航按钮 */
+.desktop-nav-btn {
+  display: inline-flex;
+}
+
+/* 手机端专用的底部导航按钮 */
+.mobile-nav-buttons {
+  display: none;
+}
+
+@media (max-width: 768px) {
+  .desktop-nav-btn {
+    display: none !important;
+  }
+  
+  .mobile-nav-buttons {
+    display: flex;
+    width: 100%;
+    gap: 12px;
+    margin-top: 16px;
+  }
+  
+  .mobile-nav-buttons :deep(.el-button) {
+    flex: 1;
+    border-radius: 12px;
+    font-weight: 500;
+  }
+  
+  .mobile-nav-buttons :deep(.el-button--primary) {
+    background: #409eff;
+    border: none;
+  }
+  
+  .progress-info {
+    margin-bottom: 0;
+  }
+}
+
+/* 深色模式支持 */
+@media (prefers-color-scheme: dark) {
+  .question-card {
+    background: rgba(30, 30, 46, 0.98);
+  }
+  
+  .nav-bar,
+  .bottom-nav {
+    background: rgba(30, 30, 46, 0.98);
+    border-color: rgba(255, 255, 255, 0.1);
+  }
+  
+  .question-title {
+    color: #f1f5f9;
+  }
+  
+  .breadcrumb {
+    color: #94a3b8;
+  }
+  
+  .markdown-content {
+    background: linear-gradient(135deg, #1e293b 0%, #0f172a 100%);
+    border-color: #334155;
+  }
+  
+  .markdown-content :deep(p),
+  .markdown-content :deep(li) {
+    color: #cbd5e1;
+  }
+  
+  .question-meta span {
+    background: #1e293b;
+    color: #94a3b8;
+  }
+}
+
+/* 安全区域适配 (iPhone X 等) */
+@supports (padding-bottom: env(safe-area-inset-bottom)) {
+  .bottom-nav {
+    padding-bottom: calc(16px + env(safe-area-inset-bottom));
+  }
+  
+  @media (max-width: 768px) {
+    .bottom-nav {
+      padding-bottom: calc(12px + env(safe-area-inset-bottom));
+    }
+  }
+}
+
+/* 横屏模式优化 */
+@media (max-height: 500px) and (orientation: landscape) {
+  .nav-bar {
+    padding: 8px 16px;
   }
   
   .question-content-wrapper {
     padding: 12px;
   }
   
-  .question-title {
-    font-size: 22px;
+  .bottom-nav {
+    padding: 8px 16px;
   }
   
-  .question-meta {
-    flex-wrap: wrap;
-    gap: 12px;
-  }
-  
-  .markdown-content {
+  .question-card :deep(.el-card__body) {
     padding: 16px;
-    font-size: 14px;
-  }
-  
-  .nav-content {
-    flex-direction: column;
-    gap: 16px;
-  }
-  
-  .progress-info {
-    order: -1;
-  }
-  
-  .progress-info .el-progress {
-    width: 250px !important;
   }
 }
-</style> 
+
+/* 打印样式 */
+@media print {
+  .nav-bar,
+  .bottom-nav,
+  .action-buttons,
+  .mode-tip {
+    display: none;
+  }
+  
+  .question-detail {
+    background: white;
+  }
+  
+  .question-card {
+    box-shadow: none;
+    border: 1px solid #e2e8f0;
+  }
+}
+</style>

--- a/vue3-user-front/src/views/plan/Index.vue
+++ b/vue3-user-front/src/views/plan/Index.vue
@@ -1,0 +1,889 @@
+<template>
+  <div class="plan-container">
+    <!-- 统计概览卡片 -->
+    <div class="stats-card">
+      <div class="stats-header">
+        <h2>📋 我的计划打卡</h2>
+        <p class="stats-subtitle">坚持每日打卡，养成好习惯</p>
+      </div>
+      <div class="stats-grid">
+        <div class="stat-item">
+          <div class="stat-value">{{ stats.totalPlans || 0 }}</div>
+          <div class="stat-label">进行中</div>
+        </div>
+        <div class="stat-item">
+          <div class="stat-value">{{ stats.todayCheckins || 0 }}</div>
+          <div class="stat-label">今日已打卡</div>
+        </div>
+        <div class="stat-item">
+          <div class="stat-value">{{ stats.totalCheckins || 0 }}</div>
+          <div class="stat-label">累计打卡</div>
+        </div>
+        <div class="stat-item">
+          <div class="stat-value">{{ stats.maxStreak || 0 }}</div>
+          <div class="stat-label">最长连续</div>
+        </div>
+      </div>
+    </div>
+
+    <!-- 今日任务区域 -->
+    <div class="section today-section">
+      <div class="section-header">
+        <h3>🎯 今日任务</h3>
+        <span class="task-count">{{ todayTasks.length }} 个任务</span>
+      </div>
+      
+      <div v-if="todayLoading" class="loading-state">
+        <el-icon class="is-loading"><Loading /></el-icon>
+        <span>加载中...</span>
+      </div>
+      
+      <div v-else-if="todayTasks.length === 0" class="empty-state">
+        <div class="empty-icon">📝</div>
+        <p>今日暂无任务，快去创建计划吧~</p>
+      </div>
+      
+      <div v-else class="task-list">
+        <div 
+          v-for="task in todayTasks" 
+          :key="task.planId"
+          class="task-card"
+          :class="{ 'completed': task.todayChecked }"
+        >
+          <div class="task-main">
+            <div class="task-info">
+              <div class="task-name">
+                <span class="type-tag" :class="getPlanTypeClass(task.planType)">
+                  {{ getPlanTypeText(task.planType) }}
+                </span>
+                {{ task.planName }}
+              </div>
+              <div class="task-target">
+                目标: {{ task.targetValue }} {{ task.targetUnit }}
+              </div>
+              <div class="task-time" v-if="task.dailyStartTime || task.dailyEndTime">
+                <el-icon><Clock /></el-icon>
+                {{ task.dailyStartTime || '--:--' }} - {{ task.dailyEndTime || '--:--' }}
+              </div>
+            </div>
+            <div class="task-progress">
+              <div class="streak-info">
+                <span class="streak-label">连续</span>
+                <span class="streak-value">{{ task.currentStreak }}</span>
+                <span class="streak-unit">天</span>
+              </div>
+            </div>
+          </div>
+          <div class="task-action">
+            <button 
+              v-if="!task.todayChecked"
+              class="checkin-btn"
+              @click="openCheckinDialog(task)"
+            >
+              <el-icon><Check /></el-icon>
+              打卡
+            </button>
+            <div v-else class="checked-badge">
+              <el-icon><SuccessFilled /></el-icon>
+              已完成
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <!-- 我的计划列表 -->
+    <div class="section plan-section">
+      <div class="section-header">
+        <h3>📑 我的计划</h3>
+        <button class="create-btn" @click="openCreateDialog">
+          <el-icon><Plus /></el-icon>
+          新建计划
+        </button>
+      </div>
+
+      <!-- 筛选条件 -->
+      <div class="filter-bar">
+        <el-select v-model="filterStatus" placeholder="全部状态" clearable @change="loadPlanList">
+          <el-option label="进行中" :value="1" />
+          <el-option label="已暂停" :value="2" />
+          <el-option label="已完成" :value="3" />
+        </el-select>
+        <el-select v-model="filterType" placeholder="全部类型" clearable @change="loadPlanList">
+          <el-option label="学习计划" :value="1" />
+          <el-option label="运动计划" :value="2" />
+          <el-option label="阅读计划" :value="3" />
+          <el-option label="编程计划" :value="4" />
+          <el-option label="其他计划" :value="99" />
+        </el-select>
+        <el-input 
+          v-model="filterKeyword" 
+          placeholder="搜索计划名称" 
+          clearable
+          @clear="loadPlanList"
+          @keyup.enter="loadPlanList"
+        >
+          <template #prefix>
+            <el-icon><Search /></el-icon>
+          </template>
+        </el-input>
+      </div>
+
+      <div v-if="planLoading" class="loading-state">
+        <el-icon class="is-loading"><Loading /></el-icon>
+        <span>加载中...</span>
+      </div>
+
+      <div v-else-if="planList.length === 0" class="empty-state">
+        <div class="empty-icon">📋</div>
+        <p>暂无计划，点击上方按钮创建你的第一个计划吧</p>
+      </div>
+
+      <div v-else class="plan-list">
+        <div 
+          v-for="plan in planList" 
+          :key="plan.id"
+          class="plan-card"
+        >
+          <div class="plan-header">
+            <div class="plan-title">
+              <span class="type-tag" :class="getPlanTypeClass(plan.planType)">
+                {{ getPlanTypeText(plan.planType) }}
+              </span>
+              <span class="plan-name">{{ plan.planName }}</span>
+              <span class="status-tag" :class="getStatusClass(plan.status)">
+                {{ getStatusText(plan.status) }}
+              </span>
+            </div>
+            <el-dropdown trigger="click" @command="handlePlanAction($event, plan)">
+              <el-icon class="more-btn"><MoreFilled /></el-icon>
+              <template #dropdown>
+                <el-dropdown-menu>
+                  <el-dropdown-item command="edit">
+                    <el-icon><Edit /></el-icon>编辑
+                  </el-dropdown-item>
+                  <el-dropdown-item command="records">
+                    <el-icon><Document /></el-icon>打卡记录
+                  </el-dropdown-item>
+                  <el-dropdown-item v-if="plan.status === 1" command="pause">
+                    <el-icon><VideoPause /></el-icon>暂停
+                  </el-dropdown-item>
+                  <el-dropdown-item v-if="plan.status === 2" command="resume">
+                    <el-icon><VideoPlay /></el-icon>恢复
+                  </el-dropdown-item>
+                  <el-dropdown-item command="delete" divided>
+                    <el-icon><Delete /></el-icon>删除
+                  </el-dropdown-item>
+                </el-dropdown-menu>
+              </template>
+            </el-dropdown>
+          </div>
+          
+          <div class="plan-desc" v-if="plan.planDesc">{{ plan.planDesc }}</div>
+          
+          <div class="plan-meta">
+            <div class="meta-item">
+              <el-icon><Calendar /></el-icon>
+              {{ formatDate(plan.startDate) }} - {{ plan.endDate ? formatDate(plan.endDate) : '长期' }}
+            </div>
+            <div class="meta-item">
+              <el-icon><Aim /></el-icon>
+              {{ plan.targetValue }} {{ plan.targetUnit }}
+            </div>
+          </div>
+          
+          <div class="plan-stats">
+            <div class="stat">
+              <span class="stat-num">{{ plan.totalCheckinDays }}</span>
+              <span class="stat-text">累计打卡</span>
+            </div>
+            <div class="stat">
+              <span class="stat-num">{{ plan.currentStreak }}</span>
+              <span class="stat-text">当前连续</span>
+            </div>
+            <div class="stat">
+              <span class="stat-num">{{ plan.maxStreak }}</span>
+              <span class="stat-text">最长连续</span>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <!-- 分页 -->
+      <div class="pagination" v-if="total > pageSize">
+        <el-pagination
+          v-model:current-page="pageNum"
+          v-model:page-size="pageSize"
+          :total="total"
+          layout="prev, pager, next"
+          @current-change="loadPlanList"
+        />
+      </div>
+    </div>
+
+    <!-- 创建/编辑计划弹窗 -->
+    <PlanFormDialog 
+      v-model="showFormDialog"
+      :plan-data="editingPlan"
+      @success="onPlanSaved"
+    />
+
+    <!-- 打卡弹窗 -->
+    <CheckinDialog 
+      v-model="showCheckinDialog"
+      :task="checkinTask"
+      @success="onCheckinSuccess"
+    />
+
+    <!-- 打卡记录弹窗 -->
+    <CheckinRecordDialog 
+      v-model="showRecordDialog"
+      :plan-id="recordPlanId"
+      :plan-name="recordPlanName"
+    />
+  </div>
+</template>
+
+<script setup>
+import { ref, onMounted } from 'vue'
+import { ElMessage, ElMessageBox } from 'element-plus'
+import { 
+  Loading, Clock, Check, SuccessFilled, Plus, Search, MoreFilled,
+  Edit, Document, VideoPause, VideoPlay, Delete, Calendar, Aim
+} from '@element-plus/icons-vue'
+import planApi from '@/api/plan'
+import PlanFormDialog from './components/PlanFormDialog.vue'
+import CheckinDialog from './components/CheckinDialog.vue'
+import CheckinRecordDialog from './components/CheckinRecordDialog.vue'
+
+// 统计数据
+const stats = ref({})
+
+// 今日任务
+const todayTasks = ref([])
+const todayLoading = ref(false)
+
+// 计划列表
+const planList = ref([])
+const planLoading = ref(false)
+const pageNum = ref(1)
+const pageSize = ref(10)
+const total = ref(0)
+
+// 筛选条件
+const filterStatus = ref(null)
+const filterType = ref(null)
+const filterKeyword = ref('')
+
+// 弹窗控制
+const showFormDialog = ref(false)
+const editingPlan = ref(null)
+const showCheckinDialog = ref(false)
+const checkinTask = ref(null)
+const showRecordDialog = ref(false)
+const recordPlanId = ref(null)
+const recordPlanName = ref('')
+
+// 页面初始化
+onMounted(() => {
+  loadStats()
+  loadTodayTasks()
+  loadPlanList()
+})
+
+// 加载统计数据
+const loadStats = async () => {
+  try {
+    const response = await planApi.getStatsOverview()
+    stats.value = response || {}
+  } catch (error) {
+    console.error('加载统计数据失败:', error)
+  }
+}
+
+// 加载今日任务
+const loadTodayTasks = async () => {
+  todayLoading.value = true
+  try {
+    const response = await planApi.getTodayTasks()
+    todayTasks.value = response || []
+  } catch (error) {
+    console.error('加载今日任务失败:', error)
+  } finally {
+    todayLoading.value = false
+  }
+}
+
+// 加载计划列表
+const loadPlanList = async () => {
+  planLoading.value = true
+  try {
+    const response = await planApi.getPlanList({
+      pageNum: pageNum.value,
+      pageSize: pageSize.value,
+      status: filterStatus.value,
+      planType: filterType.value,
+      keyword: filterKeyword.value
+    })
+    planList.value = response.records || []
+    total.value = response.total || 0
+  } catch (error) {
+    console.error('加载计划列表失败:', error)
+  } finally {
+    planLoading.value = false
+  }
+}
+
+// 打开创建弹窗
+const openCreateDialog = () => {
+  editingPlan.value = null
+  showFormDialog.value = true
+}
+
+// 打开打卡弹窗
+const openCheckinDialog = (task) => {
+  checkinTask.value = task
+  showCheckinDialog.value = true
+}
+
+// 处理计划操作
+const handlePlanAction = async (command, plan) => {
+  switch (command) {
+    case 'edit':
+      editingPlan.value = plan
+      showFormDialog.value = true
+      break
+    case 'records':
+      recordPlanId.value = plan.id
+      recordPlanName.value = plan.planName
+      showRecordDialog.value = true
+      break
+    case 'pause':
+      await handlePausePlan(plan)
+      break
+    case 'resume':
+      await handleResumePlan(plan)
+      break
+    case 'delete':
+      await handleDeletePlan(plan)
+      break
+  }
+}
+
+// 暂停计划
+const handlePausePlan = async (plan) => {
+  try {
+    await ElMessageBox.confirm('确定要暂停该计划吗？暂停后将不再生成提醒', '提示', {
+      confirmButtonText: '确定',
+      cancelButtonText: '取消',
+      type: 'warning'
+    })
+    await planApi.pausePlan(plan.id)
+    ElMessage.success('计划已暂停')
+    loadPlanList()
+    loadTodayTasks()
+  } catch (error) {
+    if (error !== 'cancel') {
+      console.error('暂停计划失败:', error)
+      ElMessage.error('暂停失败')
+    }
+  }
+}
+
+// 恢复计划
+const handleResumePlan = async (plan) => {
+  try {
+    await planApi.resumePlan(plan.id)
+    ElMessage.success('计划已恢复')
+    loadPlanList()
+    loadTodayTasks()
+  } catch (error) {
+    console.error('恢复计划失败:', error)
+    ElMessage.error('恢复失败')
+  }
+}
+
+// 删除计划
+const handleDeletePlan = async (plan) => {
+  try {
+    await ElMessageBox.confirm('确定要删除该计划吗？删除后数据无法恢复', '警告', {
+      confirmButtonText: '删除',
+      cancelButtonText: '取消',
+      type: 'error'
+    })
+    await planApi.deletePlan(plan.id)
+    ElMessage.success('计划已删除')
+    loadPlanList()
+    loadTodayTasks()
+    loadStats()
+  } catch (error) {
+    if (error !== 'cancel') {
+      console.error('删除计划失败:', error)
+      ElMessage.error('删除失败')
+    }
+  }
+}
+
+// 计划保存成功
+const onPlanSaved = () => {
+  loadPlanList()
+  loadTodayTasks()
+  loadStats()
+}
+
+// 打卡成功
+const onCheckinSuccess = () => {
+  loadTodayTasks()
+  loadPlanList()
+  loadStats()
+}
+
+// 获取计划类型文本
+const getPlanTypeText = (type) => {
+  const typeMap = {
+    1: '学习',
+    2: '运动',
+    3: '阅读',
+    4: '编程',
+    99: '其他'
+  }
+  return typeMap[type] || '其他'
+}
+
+// 获取计划类型样式
+const getPlanTypeClass = (type) => {
+  const classMap = {
+    1: 'type-study',
+    2: 'type-sport',
+    3: 'type-read',
+    4: 'type-code',
+    99: 'type-other'
+  }
+  return classMap[type] || 'type-other'
+}
+
+// 获取状态文本
+const getStatusText = (status) => {
+  const statusMap = {
+    1: '进行中',
+    2: '已暂停',
+    3: '已完成'
+  }
+  return statusMap[status] || '未知'
+}
+
+// 获取状态样式
+const getStatusClass = (status) => {
+  const classMap = {
+    1: 'status-active',
+    2: 'status-paused',
+    3: 'status-completed'
+  }
+  return classMap[status] || ''
+}
+
+// 格式化日期
+const formatDate = (dateStr) => {
+  if (!dateStr) return ''
+  const date = new Date(dateStr)
+  return date.toLocaleDateString('zh-CN', { month: 'short', day: 'numeric' })
+}
+</script>
+
+<style lang="scss" scoped>
+.plan-container {
+  padding: 24px 32px;
+  background: #f5f7fa;
+  min-height: calc(100vh - 60px);
+  
+  @media (max-width: 768px) {
+    padding: 16px;
+  }
+}
+
+// 统计卡片
+.stats-card {
+  background: white;
+  border-radius: 16px;
+  padding: 24px 32px;
+  margin-bottom: 24px;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.stats-header {
+  text-align: left;
+  margin-bottom: 20px;
+  
+  h2 {
+    font-size: 20px;
+    font-weight: 600;
+    margin: 0 0 4px 0;
+    color: #333;
+  }
+  
+  .stats-subtitle {
+    font-size: 14px;
+    color: #999;
+    margin: 0;
+  }
+}
+
+.stats-grid {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 16px;
+  
+  @media (max-width: 600px) {
+    grid-template-columns: repeat(2, 1fr);
+  }
+}
+
+.stat-item {
+  text-align: center;
+  padding: 16px 12px;
+  background: #f8f9fc;
+  border-radius: 12px;
+  
+  .stat-value {
+    font-size: 28px;
+    font-weight: bold;
+    color: #409eff;
+  }
+  
+  .stat-label {
+    font-size: 13px;
+    color: #666;
+    margin-top: 4px;
+  }
+}
+
+// 区块通用样式
+.section {
+  background: white;
+  border-radius: 16px;
+  padding: 24px;
+  margin-bottom: 24px;
+  box-shadow: 0 4px 12px rgba(0,0,0,0.08);
+}
+
+.section-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 20px;
+  
+  h3 {
+    font-size: 18px;
+    font-weight: 600;
+    margin: 0;
+    color: #333;
+  }
+  
+  .task-count {
+    font-size: 14px;
+    color: #999;
+  }
+}
+
+.create-btn {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  background: #409eff;
+  color: white;
+  border: none;
+  border-radius: 8px;
+  padding: 10px 16px;
+  font-size: 14px;
+  cursor: pointer;
+  transition: all 0.3s;
+  
+  &:hover {
+    background: #337ecc;
+    transform: translateY(-1px);
+  }
+}
+
+// 加载和空状态
+.loading-state, .empty-state {
+  text-align: center;
+  padding: 40px 20px;
+  color: #999;
+  
+  .empty-icon {
+    font-size: 48px;
+    margin-bottom: 12px;
+  }
+  
+  p {
+    margin: 0;
+  }
+}
+
+.loading-state {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+}
+
+// 今日任务卡片
+.task-list {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.task-card {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 16px;
+  background: #f8f9fc;
+  border-radius: 12px;
+  border: 2px solid transparent;
+  transition: all 0.3s;
+  
+  &:hover {
+    border-color: #409eff;
+  }
+  
+  &.completed {
+    background: #f0f9eb;
+    border-color: #67c23a;
+  }
+}
+
+.task-main {
+  display: flex;
+  align-items: center;
+  gap: 20px;
+  flex: 1;
+}
+
+.task-info {
+  .task-name {
+    font-size: 16px;
+    font-weight: 500;
+    color: #333;
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    margin-bottom: 6px;
+  }
+  
+  .task-target {
+    font-size: 13px;
+    color: #666;
+    margin-bottom: 4px;
+  }
+  
+  .task-time {
+    font-size: 12px;
+    color: #999;
+    display: flex;
+    align-items: center;
+    gap: 4px;
+  }
+}
+
+.task-progress {
+  .streak-info {
+    text-align: center;
+    
+    .streak-label {
+      font-size: 12px;
+      color: #999;
+    }
+    
+    .streak-value {
+      font-size: 24px;
+      font-weight: bold;
+      color: #409eff;
+      margin: 0 2px;
+    }
+    
+    .streak-unit {
+      font-size: 12px;
+      color: #999;
+    }
+  }
+}
+
+.task-action {
+  .checkin-btn {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    background: #409eff;
+    color: white;
+    border: none;
+    border-radius: 8px;
+    padding: 10px 20px;
+    font-size: 14px;
+    cursor: pointer;
+    transition: all 0.3s;
+    
+    &:hover {
+      background: #337ecc;
+      transform: scale(1.02);
+    }
+  }
+  
+  .checked-badge {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    color: #67c23a;
+    font-size: 14px;
+    font-weight: 500;
+  }
+}
+
+// 类型标签
+.type-tag {
+  font-size: 12px;
+  padding: 2px 8px;
+  border-radius: 4px;
+  
+  &.type-study { background: #e8f4fd; color: #409eff; }
+  &.type-sport { background: #fdf2e9; color: #e6a23c; }
+  &.type-read { background: #f0f9eb; color: #67c23a; }
+  &.type-code { background: #f4ecfb; color: #9c27b0; }
+  &.type-other { background: #f5f5f5; color: #909399; }
+}
+
+// 状态标签
+.status-tag {
+  font-size: 12px;
+  padding: 2px 8px;
+  border-radius: 4px;
+  margin-left: 8px;
+  
+  &.status-active { background: #e8f5e9; color: #4caf50; }
+  &.status-paused { background: #fff3e0; color: #ff9800; }
+  &.status-completed { background: #e3f2fd; color: #2196f3; }
+}
+
+// 筛选条件
+.filter-bar {
+  display: flex;
+  gap: 12px;
+  margin-bottom: 20px;
+  flex-wrap: wrap;
+  
+  .el-select {
+    width: 120px;
+  }
+  
+  .el-input {
+    width: 200px;
+  }
+  
+  @media (max-width: 600px) {
+    .el-select, .el-input {
+      width: 100%;
+    }
+  }
+}
+
+// 计划列表
+.plan-list {
+  display: grid;
+  gap: 16px;
+}
+
+.plan-card {
+  background: #f8f9fc;
+  border-radius: 12px;
+  padding: 20px;
+  transition: all 0.3s;
+  
+  &:hover {
+    box-shadow: 0 4px 16px rgba(0,0,0,0.1);
+  }
+}
+
+.plan-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  margin-bottom: 12px;
+}
+
+.plan-title {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 8px;
+  
+  .plan-name {
+    font-size: 16px;
+    font-weight: 600;
+    color: #333;
+  }
+}
+
+.more-btn {
+  cursor: pointer;
+  color: #999;
+  font-size: 20px;
+  padding: 4px;
+  
+  &:hover {
+    color: #409eff;
+  }
+}
+
+.plan-desc {
+  font-size: 14px;
+  color: #666;
+  margin-bottom: 12px;
+  line-height: 1.5;
+}
+
+.plan-meta {
+  display: flex;
+  gap: 20px;
+  margin-bottom: 16px;
+  flex-wrap: wrap;
+  
+  .meta-item {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    font-size: 13px;
+    color: #999;
+  }
+}
+
+.plan-stats {
+  display: flex;
+  gap: 24px;
+  padding-top: 12px;
+  border-top: 1px solid #eee;
+  
+  .stat {
+    text-align: center;
+    
+    .stat-num {
+      display: block;
+      font-size: 20px;
+      font-weight: bold;
+      color: #409eff;
+    }
+    
+    .stat-text {
+      font-size: 12px;
+      color: #999;
+    }
+  }
+}
+
+// 分页
+.pagination {
+  display: flex;
+  justify-content: center;
+  margin-top: 20px;
+}
+</style>

--- a/vue3-user-front/src/views/plan/components/CheckinDialog.vue
+++ b/vue3-user-front/src/views/plan/components/CheckinDialog.vue
@@ -1,0 +1,269 @@
+<template>
+  <el-dialog
+    :model-value="modelValue"
+    @update:model-value="emit('update:modelValue', $event)"
+    title="任务打卡"
+    width="450px"
+    :close-on-click-modal="false"
+  >
+    <div class="checkin-content" v-if="task">
+      <!-- 任务信息 -->
+      <div class="task-info">
+        <div class="task-name">{{ task.planName }}</div>
+        <div class="task-target">
+          今日目标: <strong>{{ task.targetValue }} {{ task.targetUnit }}</strong>
+        </div>
+      </div>
+
+      <!-- 打卡表单 -->
+      <el-form ref="formRef" :model="form" :rules="rules" label-position="top">
+        <el-form-item label="今日完成量" prop="actualValue">
+          <div class="value-input">
+            <el-input-number 
+              v-model="form.actualValue" 
+              :min="0"
+              :max="9999"
+              size="large"
+            />
+            <span class="unit">{{ task.targetUnit }}</span>
+          </div>
+          <div class="quick-buttons">
+            <el-button 
+              v-for="percent in [50, 75, 100, 120]" 
+              :key="percent"
+              size="small"
+              @click="setQuickValue(percent)"
+            >
+              {{ percent }}%
+            </el-button>
+          </div>
+        </el-form-item>
+
+        <el-form-item label="打卡心得（选填）">
+          <el-input
+            v-model="form.remark"
+            type="textarea"
+            placeholder="记录今天的感受或收获..."
+            :rows="3"
+            maxlength="200"
+            show-word-limit
+          />
+        </el-form-item>
+      </el-form>
+
+      <!-- 打卡进度 -->
+      <div class="progress-section">
+        <div class="progress-label">
+          <span>完成进度</span>
+          <span class="progress-percent">{{ completionPercent }}%</span>
+        </div>
+        <el-progress 
+          :percentage="completionPercent" 
+          :color="progressColor"
+          :stroke-width="12"
+        />
+      </div>
+
+      <!-- 连续打卡提示 -->
+      <div class="streak-tip" v-if="task.currentStreak > 0">
+        🔥 已连续打卡 <strong>{{ task.currentStreak }}</strong> 天，继续加油！
+      </div>
+    </div>
+
+    <template #footer>
+      <el-button @click="emit('update:modelValue', false)">取消</el-button>
+      <el-button 
+        type="primary" 
+        @click="handleCheckin" 
+        :loading="submitting"
+        :disabled="!form.actualValue || form.actualValue <= 0"
+      >
+        <el-icon v-if="!submitting"><Check /></el-icon>
+        确认打卡
+      </el-button>
+    </template>
+  </el-dialog>
+</template>
+
+<script setup>
+import { ref, computed, watch } from 'vue'
+import { ElMessage } from 'element-plus'
+import { Check } from '@element-plus/icons-vue'
+import planApi from '@/api/plan'
+
+const props = defineProps({
+  modelValue: Boolean,
+  task: Object
+})
+
+const emit = defineEmits(['update:modelValue', 'success'])
+
+const formRef = ref(null)
+const submitting = ref(false)
+
+const form = ref({
+  actualValue: 0,
+  remark: ''
+})
+
+const rules = {
+  actualValue: [
+    { required: true, message: '请输入完成量', trigger: 'blur' }
+  ]
+}
+
+// 监听弹窗打开
+watch(() => props.modelValue, (val) => {
+  if (val && props.task) {
+    // 默认填充目标值
+    form.value.actualValue = props.task.targetValue
+    form.value.remark = ''
+  }
+})
+
+// 计算完成百分比
+const completionPercent = computed(() => {
+  if (!props.task?.targetValue) return 0
+  const percent = Math.round((form.value.actualValue / props.task.targetValue) * 100)
+  return Math.min(percent, 100)
+})
+
+// 进度条颜色
+const progressColor = computed(() => {
+  const percent = completionPercent.value
+  if (percent >= 100) return '#67c23a'
+  if (percent >= 80) return '#409eff'
+  if (percent >= 50) return '#e6a23c'
+  return '#f56c6c'
+})
+
+// 快速设置百分比值
+const setQuickValue = (percent) => {
+  if (props.task?.targetValue) {
+    form.value.actualValue = Math.round(props.task.targetValue * percent / 100)
+  }
+}
+
+// 提交打卡
+const handleCheckin = async () => {
+  try {
+    await formRef.value.validate()
+    
+    if (form.value.actualValue <= 0) {
+      ElMessage.warning('完成量必须大于0')
+      return
+    }
+    
+    submitting.value = true
+    
+    const response = await planApi.checkin({
+      planId: props.task.planId,
+      actualValue: form.value.actualValue,
+      remark: form.value.remark
+    })
+    
+    // 显示打卡成功信息
+    let message = '🎉 打卡成功！'
+    if (response.currentStreak > 1) {
+      message += ` 已连续打卡 ${response.currentStreak} 天`
+    }
+    
+    ElMessage.success(message)
+    emit('success')
+    emit('update:modelValue', false)
+    
+  } catch (error) {
+    console.error('打卡失败:', error)
+    ElMessage.error(error.message || '打卡失败')
+  } finally {
+    submitting.value = false
+  }
+}
+</script>
+
+<style lang="scss" scoped>
+.checkin-content {
+  padding: 10px 0;
+}
+
+.task-info {
+  text-align: center;
+  padding: 20px;
+  background: #409eff;
+  border-radius: 12px;
+  color: white;
+  margin-bottom: 24px;
+  
+  .task-name {
+    font-size: 18px;
+    font-weight: 600;
+    margin-bottom: 8px;
+  }
+  
+  .task-target {
+    font-size: 14px;
+    opacity: 0.9;
+    
+    strong {
+      font-size: 20px;
+    }
+  }
+}
+
+.value-input {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  
+  .el-input-number {
+    flex: 1;
+  }
+  
+  .unit {
+    font-size: 16px;
+    color: #666;
+  }
+}
+
+.quick-buttons {
+  display: flex;
+  gap: 8px;
+  margin-top: 12px;
+  
+  .el-button {
+    flex: 1;
+  }
+}
+
+.progress-section {
+  margin: 24px 0;
+  
+  .progress-label {
+    display: flex;
+    justify-content: space-between;
+    margin-bottom: 8px;
+    font-size: 14px;
+    color: #666;
+    
+    .progress-percent {
+      font-weight: 600;
+      color: #333;
+    }
+  }
+}
+
+.streak-tip {
+  text-align: center;
+  padding: 12px;
+  background: #fff7e6;
+  border-radius: 8px;
+  color: #d48806;
+  font-size: 14px;
+  
+  strong {
+    color: #fa8c16;
+    font-size: 18px;
+    margin: 0 2px;
+  }
+}
+</style>

--- a/vue3-user-front/src/views/plan/components/CheckinRecordDialog.vue
+++ b/vue3-user-front/src/views/plan/components/CheckinRecordDialog.vue
@@ -1,0 +1,288 @@
+<template>
+  <el-dialog
+    :model-value="modelValue"
+    @update:model-value="emit('update:modelValue', $event)"
+    :title="`${planName} - 打卡记录`"
+    width="650px"
+    :close-on-click-modal="true"
+  >
+    <div class="record-content">
+      <!-- 统计摘要 -->
+      <div class="stats-summary">
+        <div class="stat-card">
+          <div class="stat-value">{{ totalRecords }}</div>
+          <div class="stat-label">累计打卡</div>
+        </div>
+        <div class="stat-card">
+          <div class="stat-value">{{ completionRate }}%</div>
+          <div class="stat-label">达标率</div>
+        </div>
+      </div>
+
+      <!-- 记录列表 -->
+      <div class="record-list" v-loading="loading">
+        <div v-if="records.length === 0 && !loading" class="empty-state">
+          <el-empty description="暂无打卡记录" />
+        </div>
+        
+        <div 
+          v-for="record in records" 
+          :key="record.id"
+          class="record-item"
+        >
+          <div class="record-date">
+            <div class="date-day">{{ formatDay(record.checkinDate) }}</div>
+            <div class="date-weekday">{{ formatWeekday(record.checkinDate) }}</div>
+          </div>
+          
+          <div class="record-main">
+            <div class="record-value">
+              <span class="value">{{ record.actualValue }}</span>
+              <span class="target">/ {{ record.targetValue }} {{ targetUnit }}</span>
+              <el-tag 
+                size="small" 
+                :type="record.completionRate >= 100 ? 'success' : 'warning'"
+              >
+                {{ record.completionRate }}%
+              </el-tag>
+            </div>
+            <div class="record-remark" v-if="record.remark">
+              "{{ record.remark }}"
+            </div>
+            <div class="record-time">
+              {{ formatTime(record.checkinTime) }}
+            </div>
+          </div>
+
+          <div class="record-status">
+            <el-icon v-if="record.completionRate >= 100" class="success"><SuccessFilled /></el-icon>
+            <el-icon v-else class="partial"><WarningFilled /></el-icon>
+          </div>
+        </div>
+      </div>
+
+      <!-- 加载更多 -->
+      <div class="load-more" v-if="hasMore">
+        <el-button @click="loadMore" :loading="loading" text>
+          加载更多
+        </el-button>
+      </div>
+    </div>
+  </el-dialog>
+</template>
+
+<script setup>
+import { ref, watch, computed } from 'vue'
+import { SuccessFilled, WarningFilled } from '@element-plus/icons-vue'
+import planApi from '@/api/plan'
+
+const props = defineProps({
+  modelValue: Boolean,
+  planId: Number,
+  planName: String
+})
+
+const emit = defineEmits(['update:modelValue'])
+
+const loading = ref(false)
+const records = ref([])
+const targetUnit = ref('')
+
+// 计算属性
+const totalRecords = computed(() => records.value.length)
+const hasMore = computed(() => false) // 后端返回全部记录，不需要分页
+const completionRate = computed(() => {
+  if (records.value.length === 0) return 0
+  const completed = records.value.filter(r => r.completionRate >= 100).length
+  return Math.round((completed / records.value.length) * 100)
+})
+
+// 监听弹窗打开
+watch(() => props.modelValue, (val) => {
+  if (val && props.planId) {
+    records.value = []
+    loadRecords()
+  }
+})
+
+// 加载打卡记录
+const loadRecords = async () => {
+  loading.value = true
+  try {
+    const response = await planApi.getCheckinRecords(props.planId)
+    records.value = response || []
+    
+    // 获取目标单位
+    if (records.value.length > 0 && !targetUnit.value) {
+      targetUnit.value = records.value[0].targetUnit || ''
+    }
+  } catch (error) {
+    console.error('加载打卡记录失败:', error)
+  } finally {
+    loading.value = false
+  }
+}
+
+// 加载更多（保留以防模板报错）
+const loadMore = () => {
+  // 后端返回全部记录，不需要分页
+}
+
+// 格式化日期 - 日
+const formatDay = (dateStr) => {
+  if (!dateStr) return ''
+  const date = new Date(dateStr)
+  return date.getDate()
+}
+
+// 格式化日期 - 星期
+const formatWeekday = (dateStr) => {
+  if (!dateStr) return ''
+  const date = new Date(dateStr)
+  const weekdays = ['日', '一', '二', '三', '四', '五', '六']
+  const month = date.getMonth() + 1
+  return `${month}月 周${weekdays[date.getDay()]}`
+}
+
+// 格式化时间
+const formatTime = (timeStr) => {
+  if (!timeStr) return ''
+  const date = new Date(timeStr)
+  return date.toLocaleTimeString('zh-CN', { 
+    hour: '2-digit', 
+    minute: '2-digit' 
+  })
+}
+</script>
+
+<style lang="scss" scoped>
+.record-content {
+  min-height: 300px;
+}
+
+.stats-summary {
+  display: flex;
+  gap: 16px;
+  margin-bottom: 24px;
+}
+
+.stat-card {
+  flex: 1;
+  background: #409eff;
+  border-radius: 12px;
+  padding: 20px;
+  text-align: center;
+  color: white;
+  
+  .stat-value {
+    font-size: 28px;
+    font-weight: bold;
+  }
+  
+  .stat-label {
+    font-size: 13px;
+    opacity: 0.9;
+    margin-top: 4px;
+  }
+}
+
+.record-list {
+  max-height: 400px;
+  overflow-y: auto;
+}
+
+.empty-state {
+  padding: 40px 0;
+}
+
+.record-item {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  padding: 16px;
+  background: #f8f9fc;
+  border-radius: 12px;
+  margin-bottom: 12px;
+  transition: all 0.3s;
+  
+  &:hover {
+    background: #f0f2f8;
+  }
+  
+  &:last-child {
+    margin-bottom: 0;
+  }
+}
+
+.record-date {
+  width: 60px;
+  text-align: center;
+  
+  .date-day {
+    font-size: 24px;
+    font-weight: bold;
+    color: #409eff;
+    line-height: 1;
+  }
+  
+  .date-weekday {
+    font-size: 12px;
+    color: #999;
+    margin-top: 4px;
+  }
+}
+
+.record-main {
+  flex: 1;
+  
+  .record-value {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    margin-bottom: 6px;
+    
+    .value {
+      font-size: 18px;
+      font-weight: 600;
+      color: #333;
+    }
+    
+    .target {
+      font-size: 14px;
+      color: #999;
+    }
+  }
+  
+  .record-remark {
+    font-size: 13px;
+    color: #666;
+    font-style: italic;
+    margin-bottom: 4px;
+    line-height: 1.4;
+  }
+  
+  .record-time {
+    font-size: 12px;
+    color: #999;
+  }
+}
+
+.record-status {
+  .el-icon {
+    font-size: 24px;
+    
+    &.success {
+      color: #67c23a;
+    }
+    
+    &.partial {
+      color: #e6a23c;
+    }
+  }
+}
+
+.load-more {
+  text-align: center;
+  padding: 16px 0 8px;
+}
+</style>

--- a/vue3-user-front/src/views/plan/components/PlanFormDialog.vue
+++ b/vue3-user-front/src/views/plan/components/PlanFormDialog.vue
@@ -1,0 +1,376 @@
+<template>
+  <el-dialog
+    :model-value="modelValue"
+    @update:model-value="emit('update:modelValue', $event)"
+    :title="isEdit ? '编辑计划' : '创建计划'"
+    width="600px"
+    :close-on-click-modal="false"
+    @close="handleClose"
+  >
+    <el-form 
+      ref="formRef" 
+      :model="form" 
+      :rules="rules" 
+      label-width="100px"
+      label-position="top"
+    >
+      <el-form-item label="计划名称" prop="planName">
+        <el-input 
+          v-model="form.planName" 
+          placeholder="给你的计划起个名字吧"
+          maxlength="50"
+          show-word-limit
+        />
+      </el-form-item>
+
+      <el-form-item label="计划描述" prop="planDesc">
+        <el-input 
+          v-model="form.planDesc" 
+          type="textarea"
+          placeholder="简单描述一下你的计划（选填）"
+          :rows="3"
+          maxlength="200"
+          show-word-limit
+        />
+      </el-form-item>
+
+      <el-row :gutter="20">
+        <el-col :span="12">
+          <el-form-item label="计划类型" prop="planType">
+            <el-select v-model="form.planType" placeholder="选择类型" style="width: 100%">
+              <el-option label="学习计划" :value="1">
+                <span>📚 学习计划</span>
+              </el-option>
+              <el-option label="运动计划" :value="2">
+                <span>🏃 运动计划</span>
+              </el-option>
+              <el-option label="阅读计划" :value="3">
+                <span>📖 阅读计划</span>
+              </el-option>
+              <el-option label="编程计划" :value="4">
+                <span>💻 编程计划</span>
+              </el-option>
+              <el-option label="其他计划" :value="99">
+                <span>📋 其他计划</span>
+              </el-option>
+            </el-select>
+          </el-form-item>
+        </el-col>
+        <el-col :span="12">
+          <el-form-item label="目标类型" prop="targetType">
+            <el-select v-model="form.targetType" placeholder="选择目标类型" style="width: 100%">
+              <el-option label="每日目标" :value="1" />
+              <el-option label="累计目标" :value="2" />
+            </el-select>
+          </el-form-item>
+        </el-col>
+      </el-row>
+
+      <el-row :gutter="20">
+        <el-col :span="12">
+          <el-form-item label="目标数值" prop="targetValue">
+            <el-input-number 
+              v-model="form.targetValue" 
+              :min="1" 
+              :max="9999"
+              style="width: 100%"
+            />
+          </el-form-item>
+        </el-col>
+        <el-col :span="12">
+          <el-form-item label="目标单位" prop="targetUnit">
+            <el-input 
+              v-model="form.targetUnit" 
+              placeholder="如：道题、分钟、页"
+              maxlength="10"
+            />
+          </el-form-item>
+        </el-col>
+      </el-row>
+
+      <el-row :gutter="20">
+        <el-col :span="12">
+          <el-form-item label="开始日期" prop="startDate">
+            <el-date-picker
+              v-model="form.startDate"
+              type="date"
+              placeholder="选择开始日期"
+              style="width: 100%"
+              value-format="YYYY-MM-DD"
+            />
+          </el-form-item>
+        </el-col>
+        <el-col :span="12">
+          <el-form-item label="结束日期">
+            <el-date-picker
+              v-model="form.endDate"
+              type="date"
+              placeholder="不选则为长期计划"
+              style="width: 100%"
+              value-format="YYYY-MM-DD"
+              :disabled-date="disabledEndDate"
+            />
+          </el-form-item>
+        </el-col>
+      </el-row>
+
+      <el-row :gutter="20">
+        <el-col :span="12">
+          <el-form-item label="每日开始时间">
+            <el-time-picker
+              v-model="form.dailyStartTime"
+              placeholder="选择时间（选填）"
+              style="width: 100%"
+              format="HH:mm"
+              value-format="HH:mm"
+            />
+          </el-form-item>
+        </el-col>
+        <el-col :span="12">
+          <el-form-item label="每日截止时间">
+            <el-time-picker
+              v-model="form.dailyEndTime"
+              placeholder="选择时间（选填）"
+              style="width: 100%"
+              format="HH:mm"
+              value-format="HH:mm"
+            />
+          </el-form-item>
+        </el-col>
+      </el-row>
+
+      <el-form-item label="重复设置">
+        <el-radio-group v-model="form.repeatType">
+          <el-radio :label="1">每天</el-radio>
+          <el-radio :label="2">工作日</el-radio>
+          <el-radio :label="3">自定义</el-radio>
+        </el-radio-group>
+      </el-form-item>
+
+      <el-form-item v-if="form.repeatType === 3" label="选择重复日">
+        <el-checkbox-group v-model="repeatDaysArray">
+          <el-checkbox label="1">周一</el-checkbox>
+          <el-checkbox label="2">周二</el-checkbox>
+          <el-checkbox label="3">周三</el-checkbox>
+          <el-checkbox label="4">周四</el-checkbox>
+          <el-checkbox label="5">周五</el-checkbox>
+          <el-checkbox label="6">周六</el-checkbox>
+          <el-checkbox label="7">周日</el-checkbox>
+        </el-checkbox-group>
+      </el-form-item>
+
+      <el-divider content-position="left">提醒设置</el-divider>
+
+      <el-form-item>
+        <el-switch v-model="form.remindEnabled" active-text="开启提醒" />
+      </el-form-item>
+
+      <template v-if="form.remindEnabled">
+        <el-row :gutter="20">
+          <el-col :span="12">
+            <el-form-item label="开始前提醒">
+              <el-select v-model="form.remindBefore" placeholder="选择提醒时间" style="width: 100%">
+                <el-option label="不提醒" :value="0" />
+                <el-option label="5分钟前" :value="5" />
+                <el-option label="10分钟前" :value="10" />
+                <el-option label="15分钟前" :value="15" />
+                <el-option label="30分钟前" :value="30" />
+                <el-option label="1小时前" :value="60" />
+              </el-select>
+            </el-form-item>
+          </el-col>
+          <el-col :span="12">
+            <el-form-item label="截止前提醒">
+              <el-select v-model="form.remindDeadline" placeholder="选择提醒时间" style="width: 100%">
+                <el-option label="不提醒" :value="0" />
+                <el-option label="5分钟前" :value="5" />
+                <el-option label="10分钟前" :value="10" />
+                <el-option label="15分钟前" :value="15" />
+                <el-option label="30分钟前" :value="30" />
+                <el-option label="1小时前" :value="60" />
+              </el-select>
+            </el-form-item>
+          </el-col>
+        </el-row>
+      </template>
+    </el-form>
+
+    <template #footer>
+      <el-button @click="handleClose">取消</el-button>
+      <el-button type="primary" @click="handleSubmit" :loading="submitting">
+        {{ isEdit ? '保存修改' : '创建计划' }}
+      </el-button>
+    </template>
+  </el-dialog>
+</template>
+
+<script setup>
+import { ref, computed, watch } from 'vue'
+import { ElMessage } from 'element-plus'
+import planApi from '@/api/plan'
+
+const props = defineProps({
+  modelValue: Boolean,
+  planData: Object
+})
+
+const emit = defineEmits(['update:modelValue', 'success'])
+
+// 是否编辑模式
+const isEdit = computed(() => !!props.planData?.id)
+
+// 表单引用
+const formRef = ref(null)
+const submitting = ref(false)
+
+// 重复日数组（用于自定义模式）
+const repeatDaysArray = ref([])
+
+// 表单数据
+const form = ref({
+  planName: '',
+  planDesc: '',
+  planType: 4, // 默认编程计划
+  targetType: 1, // 默认每日目标
+  targetValue: 1,
+  targetUnit: '道题',
+  startDate: new Date().toISOString().split('T')[0],
+  endDate: null,
+  dailyStartTime: null,
+  dailyEndTime: null,
+  repeatType: 1, // 默认每天
+  repeatDays: null,
+  remindEnabled: true,
+  remindBefore: 10,
+  remindDeadline: 30
+})
+
+// 表单校验规则
+const rules = {
+  planName: [
+    { required: true, message: '请输入计划名称', trigger: 'blur' },
+    { min: 2, max: 50, message: '名称长度在2到50个字符', trigger: 'blur' }
+  ],
+  planType: [
+    { required: true, message: '请选择计划类型', trigger: 'change' }
+  ],
+  targetType: [
+    { required: true, message: '请选择目标类型', trigger: 'change' }
+  ],
+  targetValue: [
+    { required: true, message: '请输入目标数值', trigger: 'blur' }
+  ],
+  targetUnit: [
+    { required: true, message: '请输入目标单位', trigger: 'blur' }
+  ],
+  startDate: [
+    { required: true, message: '请选择开始日期', trigger: 'change' }
+  ]
+}
+
+// 监听弹窗打开，初始化表单数据
+watch(() => props.modelValue, (val) => {
+  if (val) {
+    if (props.planData) {
+      // 编辑模式，填充数据
+      form.value = { ...props.planData }
+      if (props.planData.repeatDays) {
+        repeatDaysArray.value = props.planData.repeatDays.split(',')
+      } else {
+        repeatDaysArray.value = []
+      }
+    } else {
+      // 创建模式，重置表单
+      resetForm()
+    }
+  }
+})
+
+// 监听重复日数组变化
+watch(repeatDaysArray, (val) => {
+  form.value.repeatDays = val.length > 0 ? val.join(',') : null
+})
+
+// 禁用结束日期（不能早于开始日期）
+const disabledEndDate = (date) => {
+  if (!form.value.startDate) return false
+  return date < new Date(form.value.startDate)
+}
+
+// 重置表单
+const resetForm = () => {
+  form.value = {
+    planName: '',
+    planDesc: '',
+    planType: 4,
+    targetType: 1,
+    targetValue: 1,
+    targetUnit: '道题',
+    startDate: new Date().toISOString().split('T')[0],
+    endDate: null,
+    dailyStartTime: null,
+    dailyEndTime: null,
+    repeatType: 1,
+    repeatDays: null,
+    remindEnabled: true,
+    remindBefore: 10,
+    remindDeadline: 30
+  }
+  repeatDaysArray.value = []
+  formRef.value?.resetFields()
+}
+
+// 关闭弹窗
+const handleClose = () => {
+  emit('update:modelValue', false)
+}
+
+// 提交表单
+const handleSubmit = async () => {
+  try {
+    await formRef.value.validate()
+    
+    submitting.value = true
+    
+    const submitData = { ...form.value }
+    // 处理布尔值转数字
+    submitData.remindEnabled = submitData.remindEnabled ? 1 : 0
+    
+    if (isEdit.value) {
+      await planApi.updatePlan(props.planData.id, submitData)
+      ElMessage.success('计划修改成功')
+    } else {
+      await planApi.createPlan(submitData)
+      ElMessage.success('计划创建成功')
+    }
+    
+    emit('success')
+    handleClose()
+  } catch (error) {
+    if (error !== 'cancel') {
+      console.error('提交失败:', error)
+      ElMessage.error(error.message || '操作失败')
+    }
+  } finally {
+    submitting.value = false
+  }
+}
+</script>
+
+<style lang="scss" scoped>
+:deep(.el-dialog__body) {
+  padding-top: 10px;
+  max-height: 65vh;
+  overflow-y: auto;
+}
+
+:deep(.el-form-item__label) {
+  font-weight: 500;
+  color: #333;
+}
+
+:deep(.el-divider__text) {
+  color: #666;
+  font-size: 14px;
+}
+</style>

--- a/xiaou-application/pom.xml
+++ b/xiaou-application/pom.xml
@@ -136,6 +136,13 @@
             <version>${revision}</version>
         </dependency>
 
+        <!-- 引入plan模块 -->
+        <dependency>
+            <groupId>com.xiaou</groupId>
+            <artifactId>xiaou-plan</artifactId>
+            <version>${revision}</version>
+        </dependency>
+
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter</artifactId>

--- a/xiaou-plan/pom-xml-flattened
+++ b/xiaou-plan/pom-xml-flattened
@@ -8,10 +8,15 @@
     <version>1.6.0</version>
   </parent>
   <groupId>com.xiaou</groupId>
-  <artifactId>xiaou-user-api</artifactId>
+  <artifactId>xiaou-plan</artifactId>
   <version>1.6.0</version>
-  <name>xiaou-user-api</name>
-  <description>用户服务API模块 - 提供用户相关接口和DTO</description>
+  <name>xiaou-plan</name>
+  <description>个人计划打卡模块</description>
+  <properties>
+    <maven.compiler.target>17</maven.compiler.target>
+    <maven.compiler.source>17</maven.compiler.source>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+  </properties>
   <dependencies>
     <dependency>
       <groupId>com.xiaou</groupId>
@@ -19,9 +24,9 @@
       <version>${revision}</version>
     </dependency>
     <dependency>
-      <groupId>org.projectlombok</groupId>
-      <artifactId>lombok</artifactId>
-      <optional>true</optional>
+      <groupId>com.xiaou</groupId>
+      <artifactId>xiaou-user-api</artifactId>
+      <version>${revision}</version>
     </dependency>
   </dependencies>
 </project>

--- a/xiaou-plan/pom.xml
+++ b/xiaou-plan/pom.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>Code-Nest</artifactId>
+        <groupId>com.xiaou</groupId>
+        <version>${revision}</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>xiaou-plan</artifactId>
+    <name>xiaou-plan</name>
+    <description>个人计划打卡模块</description>
+
+    <properties>
+        <maven.compiler.source>17</maven.compiler.source>
+        <maven.compiler.target>17</maven.compiler.target>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+
+    <dependencies>
+        <!-- 公共模块 -->
+        <dependency>
+            <groupId>com.xiaou</groupId>
+            <artifactId>xiaou-common</artifactId>
+            <version>${revision}</version>
+        </dependency>
+        
+        <!-- 用户API模块 -->
+        <dependency>
+            <groupId>com.xiaou</groupId>
+            <artifactId>xiaou-user-api</artifactId>
+            <version>${revision}</version>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/xiaou-plan/src/main/java/com/xiaou/plan/controller/user/UserPlanController.java
+++ b/xiaou-plan/src/main/java/com/xiaou/plan/controller/user/UserPlanController.java
@@ -1,0 +1,226 @@
+package com.xiaou.plan.controller.user;
+
+import com.xiaou.common.core.domain.PageResult;
+import com.xiaou.common.core.domain.Result;
+import com.xiaou.common.satoken.StpUserUtil;
+import com.xiaou.plan.domain.PlanCheckinRecord;
+import com.xiaou.plan.dto.*;
+import com.xiaou.plan.service.PlanService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+/**
+ * 用户端计划控制器
+ * 
+ * @author xiaou
+ */
+@Slf4j
+@RestController
+@RequestMapping("/user/plan")
+@RequiredArgsConstructor
+public class UserPlanController {
+    
+    private final PlanService planService;
+    
+    /**
+     * 创建计划
+     */
+    @PostMapping("/create")
+    public Result<PlanResponse> createPlan(@RequestBody PlanCreateRequest request) {
+        try {
+            if (!StpUserUtil.isLogin()) {
+                return Result.error("请先登录");
+            }
+            Long userId = StpUserUtil.getLoginIdAsLong();
+            PlanResponse response = planService.createPlan(userId, request);
+            return Result.success("创建成功", response);
+        } catch (Exception e) {
+            log.error("创建计划失败", e);
+            return Result.error(e.getMessage());
+        }
+    }
+    
+    /**
+     * 更新计划
+     */
+    @PutMapping("/update/{planId}")
+    public Result<PlanResponse> updatePlan(@PathVariable Long planId, @RequestBody PlanCreateRequest request) {
+        try {
+            if (!StpUserUtil.isLogin()) {
+                return Result.error("请先登录");
+            }
+            Long userId = StpUserUtil.getLoginIdAsLong();
+            PlanResponse response = planService.updatePlan(userId, planId, request);
+            return Result.success("更新成功", response);
+        } catch (Exception e) {
+            log.error("更新计划失败", e);
+            return Result.error(e.getMessage());
+        }
+    }
+    
+    /**
+     * 删除计划
+     */
+    @DeleteMapping("/{planId}")
+    public Result<Boolean> deletePlan(@PathVariable Long planId) {
+        try {
+            if (!StpUserUtil.isLogin()) {
+                return Result.error("请先登录");
+            }
+            Long userId = StpUserUtil.getLoginIdAsLong();
+            boolean success = planService.deletePlan(userId, planId);
+            return success ? Result.success("删除成功", true) : Result.error("删除失败");
+        } catch (Exception e) {
+            log.error("删除计划失败", e);
+            return Result.error(e.getMessage());
+        }
+    }
+    
+    /**
+     * 获取计划详情
+     */
+    @GetMapping("/{planId}")
+    public Result<PlanResponse> getPlanDetail(@PathVariable Long planId) {
+        try {
+            if (!StpUserUtil.isLogin()) {
+                return Result.error("请先登录");
+            }
+            Long userId = StpUserUtil.getLoginIdAsLong();
+            PlanResponse response = planService.getPlanDetail(userId, planId);
+            return Result.success("获取成功", response);
+        } catch (Exception e) {
+            log.error("获取计划详情失败", e);
+            return Result.error(e.getMessage());
+        }
+    }
+    
+    /**
+     * 获取计划列表
+     */
+    @PostMapping("/list")
+    public Result<PageResult<PlanResponse>> getPlanList(@RequestBody PlanListRequest request) {
+        try {
+            if (!StpUserUtil.isLogin()) {
+                return Result.error("请先登录");
+            }
+            Long userId = StpUserUtil.getLoginIdAsLong();
+            request.setUserId(userId);
+            PageResult<PlanResponse> response = planService.getPlanList(request);
+            return Result.success("获取成功", response);
+        } catch (Exception e) {
+            log.error("获取计划列表失败", e);
+            return Result.error(e.getMessage());
+        }
+    }
+    
+    /**
+     * 暂停计划
+     */
+    @PutMapping("/{planId}/pause")
+    public Result<Boolean> pausePlan(@PathVariable Long planId) {
+        try {
+            if (!StpUserUtil.isLogin()) {
+                return Result.error("请先登录");
+            }
+            Long userId = StpUserUtil.getLoginIdAsLong();
+            boolean success = planService.pausePlan(userId, planId);
+            return success ? Result.success("暂停成功", true) : Result.error("暂停失败");
+        } catch (Exception e) {
+            log.error("暂停计划失败", e);
+            return Result.error(e.getMessage());
+        }
+    }
+    
+    /**
+     * 恢复计划
+     */
+    @PutMapping("/{planId}/resume")
+    public Result<Boolean> resumePlan(@PathVariable Long planId) {
+        try {
+            if (!StpUserUtil.isLogin()) {
+                return Result.error("请先登录");
+            }
+            Long userId = StpUserUtil.getLoginIdAsLong();
+            boolean success = planService.resumePlan(userId, planId);
+            return success ? Result.success("恢复成功", true) : Result.error("恢复失败");
+        } catch (Exception e) {
+            log.error("恢复计划失败", e);
+            return Result.error(e.getMessage());
+        }
+    }
+    
+    /**
+     * 获取今日任务列表
+     */
+    @GetMapping("/today-tasks")
+    public Result<List<TodayTaskResponse>> getTodayTasks() {
+        try {
+            if (!StpUserUtil.isLogin()) {
+                return Result.error("请先登录");
+            }
+            Long userId = StpUserUtil.getLoginIdAsLong();
+            List<TodayTaskResponse> tasks = planService.getTodayTasks(userId);
+            return Result.success("获取成功", tasks);
+        } catch (Exception e) {
+            log.error("获取今日任务失败", e);
+            return Result.error(e.getMessage());
+        }
+    }
+    
+    /**
+     * 执行打卡
+     */
+    @PostMapping("/checkin")
+    public Result<PlanCheckinResponse> checkin(@RequestBody PlanCheckinRequest request) {
+        try {
+            if (!StpUserUtil.isLogin()) {
+                return Result.error("请先登录");
+            }
+            Long userId = StpUserUtil.getLoginIdAsLong();
+            PlanCheckinResponse response = planService.checkin(userId, request);
+            return Result.success("打卡成功", response);
+        } catch (Exception e) {
+            log.error("打卡失败", e);
+            return Result.error(e.getMessage());
+        }
+    }
+    
+    /**
+     * 获取计划打卡记录
+     */
+    @GetMapping("/{planId}/checkin/list")
+    public Result<List<PlanCheckinRecord>> getCheckinRecords(@PathVariable Long planId) {
+        try {
+            if (!StpUserUtil.isLogin()) {
+                return Result.error("请先登录");
+            }
+            Long userId = StpUserUtil.getLoginIdAsLong();
+            List<PlanCheckinRecord> records = planService.getCheckinRecords(userId, planId);
+            return Result.success("获取成功", records);
+        } catch (Exception e) {
+            log.error("获取打卡记录失败", e);
+            return Result.error(e.getMessage());
+        }
+    }
+    
+    /**
+     * 获取统计概览
+     */
+    @GetMapping("/stats/overview")
+    public Result<PlanStatsResponse> getStatsOverview() {
+        try {
+            if (!StpUserUtil.isLogin()) {
+                return Result.error("请先登录");
+            }
+            Long userId = StpUserUtil.getLoginIdAsLong();
+            PlanStatsResponse response = planService.getStatsOverview(userId);
+            return Result.success("获取成功", response);
+        } catch (Exception e) {
+            log.error("获取统计概览失败", e);
+            return Result.error(e.getMessage());
+        }
+    }
+}

--- a/xiaou-plan/src/main/java/com/xiaou/plan/domain/PlanCheckinRecord.java
+++ b/xiaou-plan/src/main/java/com/xiaou/plan/domain/PlanCheckinRecord.java
@@ -1,0 +1,74 @@
+package com.xiaou.plan.domain;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import lombok.Data;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+/**
+ * 计划打卡记录实体类
+ * 
+ * @author xiaou
+ */
+@Data
+public class PlanCheckinRecord {
+    
+    /**
+     * 记录ID
+     */
+    private Long id;
+    
+    /**
+     * 计划ID
+     */
+    private Long planId;
+    
+    /**
+     * 用户ID
+     */
+    private Long userId;
+    
+    /**
+     * 打卡日期
+     */
+    @JsonFormat(pattern = "yyyy-MM-dd", timezone = "GMT+8")
+    private LocalDate checkinDate;
+    
+    /**
+     * 打卡时间
+     */
+    @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss", timezone = "GMT+8")
+    private LocalDateTime checkinTime;
+    
+    /**
+     * 完成数量
+     */
+    private Integer completeValue;
+    
+    /**
+     * 完成内容描述
+     */
+    private String completeContent;
+    
+    /**
+     * 心得备注
+     */
+    private String remark;
+    
+    /**
+     * 是否补卡：0-否 1-是
+     */
+    private Integer isSupplement;
+    
+    /**
+     * 获得积分
+     */
+    private Integer pointsEarned;
+    
+    /**
+     * 创建时间
+     */
+    @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss", timezone = "GMT+8")
+    private LocalDateTime createTime;
+}

--- a/xiaou-plan/src/main/java/com/xiaou/plan/domain/PlanRemindTask.java
+++ b/xiaou-plan/src/main/java/com/xiaou/plan/domain/PlanRemindTask.java
@@ -1,0 +1,65 @@
+package com.xiaou.plan.domain;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import lombok.Data;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+/**
+ * 计划提醒任务实体类
+ * 
+ * @author xiaou
+ */
+@Data
+public class PlanRemindTask {
+    
+    /**
+     * 任务ID
+     */
+    private Long id;
+    
+    /**
+     * 计划ID
+     */
+    private Long planId;
+    
+    /**
+     * 用户ID
+     */
+    private Long userId;
+    
+    /**
+     * 提醒类型：1-开始提醒 2-截止提醒
+     */
+    private Integer remindType;
+    
+    /**
+     * 提醒日期
+     */
+    @JsonFormat(pattern = "yyyy-MM-dd", timezone = "GMT+8")
+    private LocalDate remindDate;
+    
+    /**
+     * 提醒时间
+     */
+    @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss", timezone = "GMT+8")
+    private LocalDateTime remindTime;
+    
+    /**
+     * 状态：0-待发送 1-已发送 2-已取消
+     */
+    private Integer status;
+    
+    /**
+     * 实际发送时间
+     */
+    @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss", timezone = "GMT+8")
+    private LocalDateTime sendTime;
+    
+    /**
+     * 创建时间
+     */
+    @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss", timezone = "GMT+8")
+    private LocalDateTime createTime;
+}

--- a/xiaou-plan/src/main/java/com/xiaou/plan/domain/UserPlan.java
+++ b/xiaou-plan/src/main/java/com/xiaou/plan/domain/UserPlan.java
@@ -1,0 +1,138 @@
+package com.xiaou.plan.domain;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import lombok.Data;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+
+/**
+ * 用户计划实体类
+ * 
+ * @author xiaou
+ */
+@Data
+public class UserPlan {
+    
+    /**
+     * 计划ID
+     */
+    private Long id;
+    
+    /**
+     * 用户ID
+     */
+    private Long userId;
+    
+    /**
+     * 计划名称
+     */
+    private String planName;
+    
+    /**
+     * 计划描述
+     */
+    private String planDesc;
+    
+    /**
+     * 计划类型：1-刷题 2-学习 3-阅读 4-运动 5-自定义
+     */
+    private Integer planType;
+    
+    /**
+     * 目标类型：1-数量 2-时长 3-次数
+     */
+    private Integer targetType;
+    
+    /**
+     * 目标值
+     */
+    private Integer targetValue;
+    
+    /**
+     * 目标单位（道/小时/次）
+     */
+    private String targetUnit;
+    
+    /**
+     * 开始日期
+     */
+    @JsonFormat(pattern = "yyyy-MM-dd", timezone = "GMT+8")
+    private LocalDate startDate;
+    
+    /**
+     * 结束日期（NULL表示长期）
+     */
+    @JsonFormat(pattern = "yyyy-MM-dd", timezone = "GMT+8")
+    private LocalDate endDate;
+    
+    /**
+     * 每日开始时间
+     */
+    @JsonFormat(pattern = "HH:mm", timezone = "GMT+8")
+    private LocalTime dailyStartTime;
+    
+    /**
+     * 每日截止时间
+     */
+    @JsonFormat(pattern = "HH:mm", timezone = "GMT+8")
+    private LocalTime dailyEndTime;
+    
+    /**
+     * 重复类型：1-每日 2-工作日 3-周末 4-自定义
+     */
+    private Integer repeatType;
+    
+    /**
+     * 自定义重复日（如：1,2,3,4,5 表示周一到周五）
+     */
+    private String repeatDays;
+    
+    /**
+     * 提前提醒分钟数
+     */
+    private Integer remindBefore;
+    
+    /**
+     * 截止提醒分钟数
+     */
+    private Integer remindDeadline;
+    
+    /**
+     * 是否启用提醒：0-否 1-是
+     */
+    private Integer remindEnabled;
+    
+    /**
+     * 状态：0-已删除 1-进行中 2-已暂停 3-已完成 4-已过期
+     */
+    private Integer status;
+    
+    /**
+     * 累计打卡天数
+     */
+    private Integer totalCheckinDays;
+    
+    /**
+     * 当前连续打卡天数
+     */
+    private Integer currentStreak;
+    
+    /**
+     * 最长连续打卡天数
+     */
+    private Integer maxStreak;
+    
+    /**
+     * 创建时间
+     */
+    @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss", timezone = "GMT+8")
+    private LocalDateTime createTime;
+    
+    /**
+     * 更新时间
+     */
+    @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss", timezone = "GMT+8")
+    private LocalDateTime updateTime;
+}

--- a/xiaou-plan/src/main/java/com/xiaou/plan/dto/PlanCheckinRequest.java
+++ b/xiaou-plan/src/main/java/com/xiaou/plan/dto/PlanCheckinRequest.java
@@ -1,0 +1,32 @@
+package com.xiaou.plan.dto;
+
+import lombok.Data;
+
+/**
+ * 计划打卡请求DTO
+ * 
+ * @author xiaou
+ */
+@Data
+public class PlanCheckinRequest {
+    
+    /**
+     * 计划ID
+     */
+    private Long planId;
+    
+    /**
+     * 完成数量
+     */
+    private Integer completeValue;
+    
+    /**
+     * 完成内容描述
+     */
+    private String completeContent;
+    
+    /**
+     * 心得备注
+     */
+    private String remark;
+}

--- a/xiaou-plan/src/main/java/com/xiaou/plan/dto/PlanCheckinResponse.java
+++ b/xiaou-plan/src/main/java/com/xiaou/plan/dto/PlanCheckinResponse.java
@@ -1,0 +1,49 @@
+package com.xiaou.plan.dto;
+
+import lombok.Builder;
+import lombok.Data;
+
+/**
+ * 计划打卡响应DTO
+ * 
+ * @author xiaou
+ */
+@Data
+@Builder
+public class PlanCheckinResponse {
+    
+    /**
+     * 打卡记录ID
+     */
+    private Long recordId;
+    
+    /**
+     * 计划ID
+     */
+    private Long planId;
+    
+    /**
+     * 计划名称
+     */
+    private String planName;
+    
+    /**
+     * 获得积分
+     */
+    private Integer pointsEarned;
+    
+    /**
+     * 当前连续打卡天数
+     */
+    private Integer currentStreak;
+    
+    /**
+     * 累计打卡天数
+     */
+    private Integer totalCheckinDays;
+    
+    /**
+     * 打卡成功消息
+     */
+    private String message;
+}

--- a/xiaou-plan/src/main/java/com/xiaou/plan/dto/PlanCreateRequest.java
+++ b/xiaou-plan/src/main/java/com/xiaou/plan/dto/PlanCreateRequest.java
@@ -1,0 +1,95 @@
+package com.xiaou.plan.dto;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import lombok.Data;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+
+/**
+ * 创建计划请求DTO
+ * 
+ * @author xiaou
+ */
+@Data
+public class PlanCreateRequest {
+    
+    /**
+     * 计划名称
+     */
+    private String planName;
+    
+    /**
+     * 计划描述
+     */
+    private String planDesc;
+    
+    /**
+     * 计划类型：1-刷题 2-学习 3-阅读 4-运动 5-自定义
+     */
+    private Integer planType;
+    
+    /**
+     * 目标类型：1-数量 2-时长 3-次数
+     */
+    private Integer targetType;
+    
+    /**
+     * 目标值
+     */
+    private Integer targetValue;
+    
+    /**
+     * 目标单位（道/小时/次）
+     */
+    private String targetUnit;
+    
+    /**
+     * 开始日期
+     */
+    @JsonFormat(pattern = "yyyy-MM-dd", timezone = "GMT+8")
+    private LocalDate startDate;
+    
+    /**
+     * 结束日期（NULL表示长期）
+     */
+    @JsonFormat(pattern = "yyyy-MM-dd", timezone = "GMT+8")
+    private LocalDate endDate;
+    
+    /**
+     * 每日开始时间
+     */
+    @JsonFormat(pattern = "HH:mm", timezone = "GMT+8")
+    private LocalTime dailyStartTime;
+    
+    /**
+     * 每日截止时间
+     */
+    @JsonFormat(pattern = "HH:mm", timezone = "GMT+8")
+    private LocalTime dailyEndTime;
+    
+    /**
+     * 重复类型：1-每日 2-工作日 3-周末 4-自定义
+     */
+    private Integer repeatType;
+    
+    /**
+     * 自定义重复日（如：1,2,3,4,5 表示周一到周五）
+     */
+    private String repeatDays;
+    
+    /**
+     * 提前提醒分钟数
+     */
+    private Integer remindBefore;
+    
+    /**
+     * 截止提醒分钟数
+     */
+    private Integer remindDeadline;
+    
+    /**
+     * 是否启用提醒：0-否 1-是
+     */
+    private Integer remindEnabled;
+}

--- a/xiaou-plan/src/main/java/com/xiaou/plan/dto/PlanListRequest.java
+++ b/xiaou-plan/src/main/java/com/xiaou/plan/dto/PlanListRequest.java
@@ -1,0 +1,42 @@
+package com.xiaou.plan.dto;
+
+import lombok.Data;
+
+/**
+ * 计划列表查询请求DTO
+ * 
+ * @author xiaou
+ */
+@Data
+public class PlanListRequest {
+    
+    /**
+     * 用户ID（内部使用）
+     */
+    private Long userId;
+    
+    /**
+     * 计划状态筛选
+     */
+    private Integer status;
+    
+    /**
+     * 计划类型筛选
+     */
+    private Integer planType;
+    
+    /**
+     * 搜索关键字
+     */
+    private String keyword;
+    
+    /**
+     * 当前页码
+     */
+    private Integer pageNum = 1;
+    
+    /**
+     * 每页数量
+     */
+    private Integer pageSize = 10;
+}

--- a/xiaou-plan/src/main/java/com/xiaou/plan/dto/PlanResponse.java
+++ b/xiaou-plan/src/main/java/com/xiaou/plan/dto/PlanResponse.java
@@ -1,0 +1,75 @@
+package com.xiaou.plan.dto;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import lombok.Builder;
+import lombok.Data;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+
+/**
+ * 计划响应DTO
+ * 
+ * @author xiaou
+ */
+@Data
+@Builder
+public class PlanResponse {
+    
+    private Long id;
+    private Long userId;
+    private String planName;
+    private String planDesc;
+    private Integer planType;
+    private String planTypeDesc;
+    private String planTypeIcon;
+    private Integer targetType;
+    private Integer targetValue;
+    private String targetUnit;
+    
+    @JsonFormat(pattern = "yyyy-MM-dd", timezone = "GMT+8")
+    private LocalDate startDate;
+    
+    @JsonFormat(pattern = "yyyy-MM-dd", timezone = "GMT+8")
+    private LocalDate endDate;
+    
+    @JsonFormat(pattern = "HH:mm", timezone = "GMT+8")
+    private LocalTime dailyStartTime;
+    
+    @JsonFormat(pattern = "HH:mm", timezone = "GMT+8")
+    private LocalTime dailyEndTime;
+    
+    private Integer repeatType;
+    private String repeatTypeDesc;
+    private String repeatDays;
+    private Integer remindBefore;
+    private Integer remindDeadline;
+    private Integer remindEnabled;
+    private Integer status;
+    private String statusDesc;
+    private Integer totalCheckinDays;
+    private Integer currentStreak;
+    private Integer maxStreak;
+    
+    /**
+     * 完成率（百分比）
+     */
+    private Double completionRate;
+    
+    /**
+     * 今日是否已打卡
+     */
+    private Boolean todayCheckedIn;
+    
+    /**
+     * 今日是否需要打卡
+     */
+    private Boolean todayNeedCheckin;
+    
+    @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss", timezone = "GMT+8")
+    private LocalDateTime createTime;
+    
+    @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss", timezone = "GMT+8")
+    private LocalDateTime updateTime;
+}

--- a/xiaou-plan/src/main/java/com/xiaou/plan/dto/PlanStatsResponse.java
+++ b/xiaou-plan/src/main/java/com/xiaou/plan/dto/PlanStatsResponse.java
@@ -1,0 +1,54 @@
+package com.xiaou.plan.dto;
+
+import lombok.Builder;
+import lombok.Data;
+
+/**
+ * 计划统计响应DTO
+ * 
+ * @author xiaou
+ */
+@Data
+@Builder
+public class PlanStatsResponse {
+    
+    /**
+     * 进行中计划数
+     */
+    private Integer activePlanCount;
+    
+    /**
+     * 累计打卡次数
+     */
+    private Integer totalCheckinCount;
+    
+    /**
+     * 平均完成率
+     */
+    private Double avgCompletionRate;
+    
+    /**
+     * 最长连续打卡天数
+     */
+    private Integer maxStreak;
+    
+    /**
+     * 本周打卡次数
+     */
+    private Integer weekCheckinCount;
+    
+    /**
+     * 本月打卡次数
+     */
+    private Integer monthCheckinCount;
+    
+    /**
+     * 今日完成任务数
+     */
+    private Integer todayCompletedCount;
+    
+    /**
+     * 今日待完成任务数
+     */
+    private Integer todayPendingCount;
+}

--- a/xiaou-plan/src/main/java/com/xiaou/plan/dto/TodayTaskResponse.java
+++ b/xiaou-plan/src/main/java/com/xiaou/plan/dto/TodayTaskResponse.java
@@ -1,0 +1,94 @@
+package com.xiaou.plan.dto;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import lombok.Builder;
+import lombok.Data;
+
+import java.time.LocalTime;
+
+/**
+ * 今日任务响应DTO
+ * 
+ * @author xiaou
+ */
+@Data
+@Builder
+public class TodayTaskResponse {
+    
+    /**
+     * 计划ID
+     */
+    private Long planId;
+    
+    /**
+     * 计划名称
+     */
+    private String planName;
+    
+    /**
+     * 计划类型
+     */
+    private Integer planType;
+    
+    /**
+     * 计划类型描述
+     */
+    private String planTypeDesc;
+    
+    /**
+     * 计划类型图标
+     */
+    private String planTypeIcon;
+    
+    /**
+     * 目标值
+     */
+    private Integer targetValue;
+    
+    /**
+     * 目标单位
+     */
+    private String targetUnit;
+    
+    /**
+     * 每日开始时间
+     */
+    @JsonFormat(pattern = "HH:mm", timezone = "GMT+8")
+    private LocalTime dailyStartTime;
+    
+    /**
+     * 每日截止时间
+     */
+    @JsonFormat(pattern = "HH:mm", timezone = "GMT+8")
+    private LocalTime dailyEndTime;
+    
+    /**
+     * 任务状态：0-待完成 1-已完成 2-已过期
+     */
+    private Integer taskStatus;
+    
+    /**
+     * 任务状态描述
+     */
+    private String taskStatusDesc;
+    
+    /**
+     * 是否已打卡
+     */
+    private Boolean checkedIn;
+    
+    /**
+     * 剩余时间（分钟）
+     */
+    private Long remainingMinutes;
+    
+    /**
+     * 剩余时间描述
+     */
+    private String remainingTimeDesc;
+    
+    /**
+     * 当前连续打卡天数
+     */
+    private Integer currentStreak;
+}

--- a/xiaou-plan/src/main/java/com/xiaou/plan/enums/PlanStatus.java
+++ b/xiaou-plan/src/main/java/com/xiaou/plan/enums/PlanStatus.java
@@ -1,0 +1,40 @@
+package com.xiaou.plan.enums;
+
+/**
+ * 计划状态枚举
+ * 
+ * @author xiaou
+ */
+public enum PlanStatus {
+    
+    DELETED(0, "已删除"),
+    ACTIVE(1, "进行中"),
+    PAUSED(2, "已暂停"),
+    COMPLETED(3, "已完成"),
+    EXPIRED(4, "已过期");
+    
+    private final int code;
+    private final String desc;
+    
+    PlanStatus(int code, String desc) {
+        this.code = code;
+        this.desc = desc;
+    }
+    
+    public int getCode() {
+        return code;
+    }
+    
+    public String getDesc() {
+        return desc;
+    }
+    
+    public static PlanStatus fromCode(int code) {
+        for (PlanStatus status : values()) {
+            if (status.getCode() == code) {
+                return status;
+            }
+        }
+        return ACTIVE;
+    }
+}

--- a/xiaou-plan/src/main/java/com/xiaou/plan/enums/PlanType.java
+++ b/xiaou-plan/src/main/java/com/xiaou/plan/enums/PlanType.java
@@ -1,0 +1,46 @@
+package com.xiaou.plan.enums;
+
+/**
+ * 计划类型枚举
+ * 
+ * @author xiaou
+ */
+public enum PlanType {
+    
+    CODING(1, "刷题计划", "💻"),
+    STUDY(2, "学习计划", "📚"),
+    READING(3, "阅读计划", "📖"),
+    EXERCISE(4, "运动计划", "🏃"),
+    CUSTOM(5, "自定义", "✏️");
+    
+    private final int code;
+    private final String desc;
+    private final String icon;
+    
+    PlanType(int code, String desc, String icon) {
+        this.code = code;
+        this.desc = desc;
+        this.icon = icon;
+    }
+    
+    public int getCode() {
+        return code;
+    }
+    
+    public String getDesc() {
+        return desc;
+    }
+    
+    public String getIcon() {
+        return icon;
+    }
+    
+    public static PlanType fromCode(int code) {
+        for (PlanType type : values()) {
+            if (type.getCode() == code) {
+                return type;
+            }
+        }
+        return CUSTOM;
+    }
+}

--- a/xiaou-plan/src/main/java/com/xiaou/plan/enums/RepeatType.java
+++ b/xiaou-plan/src/main/java/com/xiaou/plan/enums/RepeatType.java
@@ -1,0 +1,39 @@
+package com.xiaou.plan.enums;
+
+/**
+ * 重复类型枚举
+ * 
+ * @author xiaou
+ */
+public enum RepeatType {
+    
+    DAILY(1, "每日"),
+    WORKDAY(2, "工作日"),
+    WEEKEND(3, "周末"),
+    CUSTOM(4, "自定义");
+    
+    private final int code;
+    private final String desc;
+    
+    RepeatType(int code, String desc) {
+        this.code = code;
+        this.desc = desc;
+    }
+    
+    public int getCode() {
+        return code;
+    }
+    
+    public String getDesc() {
+        return desc;
+    }
+    
+    public static RepeatType fromCode(int code) {
+        for (RepeatType type : values()) {
+            if (type.getCode() == code) {
+                return type;
+            }
+        }
+        return DAILY;
+    }
+}

--- a/xiaou-plan/src/main/java/com/xiaou/plan/mapper/PlanCheckinRecordMapper.java
+++ b/xiaou-plan/src/main/java/com/xiaou/plan/mapper/PlanCheckinRecordMapper.java
@@ -1,0 +1,64 @@
+package com.xiaou.plan.mapper;
+
+import com.xiaou.plan.domain.PlanCheckinRecord;
+import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
+
+import java.time.LocalDate;
+import java.util.List;
+
+/**
+ * 计划打卡记录Mapper接口
+ * 
+ * @author xiaou
+ */
+@Mapper
+public interface PlanCheckinRecordMapper {
+    
+    /**
+     * 插入打卡记录
+     */
+    int insert(PlanCheckinRecord record);
+    
+    /**
+     * 查询某计划某日的打卡记录
+     */
+    PlanCheckinRecord selectByPlanIdAndDate(@Param("planId") Long planId, @Param("checkinDate") LocalDate checkinDate);
+    
+    /**
+     * 查询某计划的打卡记录列表
+     */
+    List<PlanCheckinRecord> selectByPlanId(@Param("planId") Long planId);
+    
+    /**
+     * 查询用户某日所有打卡记录
+     */
+    List<PlanCheckinRecord> selectByUserIdAndDate(@Param("userId") Long userId, @Param("checkinDate") LocalDate checkinDate);
+    
+    /**
+     * 查询用户打卡记录列表
+     */
+    List<PlanCheckinRecord> selectByUserId(@Param("userId") Long userId);
+    
+    /**
+     * 统计计划打卡天数
+     */
+    int countByPlanId(@Param("planId") Long planId);
+    
+    /**
+     * 查询最近的打卡记录
+     */
+    PlanCheckinRecord selectLatestByPlanId(@Param("planId") Long planId);
+    
+    /**
+     * 查询用户某月的打卡记录
+     */
+    List<PlanCheckinRecord> selectByUserIdAndMonth(@Param("userId") Long userId, 
+                                                    @Param("year") int year, 
+                                                    @Param("month") int month);
+    
+    /**
+     * 统计用户总打卡次数
+     */
+    int countByUserId(@Param("userId") Long userId);
+}

--- a/xiaou-plan/src/main/java/com/xiaou/plan/mapper/PlanRemindTaskMapper.java
+++ b/xiaou-plan/src/main/java/com/xiaou/plan/mapper/PlanRemindTaskMapper.java
@@ -1,0 +1,56 @@
+package com.xiaou.plan.mapper;
+
+import com.xiaou.plan.domain.PlanRemindTask;
+import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+
+/**
+ * 计划提醒任务Mapper接口
+ * 
+ * @author xiaou
+ */
+@Mapper
+public interface PlanRemindTaskMapper {
+    
+    /**
+     * 插入提醒任务
+     */
+    int insert(PlanRemindTask task);
+    
+    /**
+     * 批量插入提醒任务
+     */
+    int batchInsert(@Param("tasks") List<PlanRemindTask> tasks);
+    
+    /**
+     * 查询待发送的提醒任务
+     */
+    List<PlanRemindTask> selectPendingTasks(@Param("startTime") LocalDateTime startTime, 
+                                             @Param("endTime") LocalDateTime endTime);
+    
+    /**
+     * 更新任务状态
+     */
+    int updateStatus(@Param("id") Long id, 
+                     @Param("status") Integer status, 
+                     @Param("sendTime") LocalDateTime sendTime);
+    
+    /**
+     * 取消计划的所有待发送任务
+     */
+    int cancelByPlanId(@Param("planId") Long planId);
+    
+    /**
+     * 查询某天是否已生成提醒任务
+     */
+    int countByPlanIdAndDate(@Param("planId") Long planId, @Param("remindDate") LocalDate remindDate);
+    
+    /**
+     * 删除某天之前的已发送任务（清理历史数据）
+     */
+    int deleteOldTasks(@Param("beforeDate") LocalDate beforeDate);
+}

--- a/xiaou-plan/src/main/java/com/xiaou/plan/mapper/UserPlanMapper.java
+++ b/xiaou-plan/src/main/java/com/xiaou/plan/mapper/UserPlanMapper.java
@@ -1,0 +1,81 @@
+package com.xiaou.plan.mapper;
+
+import com.xiaou.plan.domain.UserPlan;
+import com.xiaou.plan.dto.PlanListRequest;
+import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
+
+import java.time.LocalDate;
+import java.util.List;
+
+/**
+ * 用户计划Mapper接口
+ * 
+ * @author xiaou
+ */
+@Mapper
+public interface UserPlanMapper {
+    
+    /**
+     * 插入计划
+     */
+    int insert(UserPlan plan);
+    
+    /**
+     * 更新计划
+     */
+    int update(UserPlan plan);
+    
+    /**
+     * 根据ID查询计划
+     */
+    UserPlan selectById(@Param("id") Long id);
+    
+    /**
+     * 根据用户ID和计划ID查询
+     */
+    UserPlan selectByUserIdAndId(@Param("userId") Long userId, @Param("id") Long id);
+    
+    /**
+     * 查询用户计划列表
+     */
+    List<UserPlan> selectList(PlanListRequest request);
+    
+    /**
+     * 查询用户今日需要打卡的计划
+     */
+    List<UserPlan> selectTodayPlans(@Param("userId") Long userId, @Param("today") LocalDate today);
+    
+    /**
+     * 查询用户所有进行中的计划
+     */
+    List<UserPlan> selectActivePlans(@Param("userId") Long userId);
+    
+    /**
+     * 更新计划状态
+     */
+    int updateStatus(@Param("id") Long id, @Param("status") Integer status);
+    
+    /**
+     * 更新打卡统计信息
+     */
+    int updateCheckinStats(@Param("id") Long id, 
+                           @Param("totalCheckinDays") Integer totalCheckinDays,
+                           @Param("currentStreak") Integer currentStreak,
+                           @Param("maxStreak") Integer maxStreak);
+    
+    /**
+     * 逻辑删除计划
+     */
+    int deleteById(@Param("id") Long id, @Param("userId") Long userId);
+    
+    /**
+     * 查询需要生成提醒任务的计划
+     */
+    List<UserPlan> selectPlansForRemind(@Param("today") LocalDate today);
+    
+    /**
+     * 统计用户计划数量
+     */
+    int countByUserId(@Param("userId") Long userId, @Param("status") Integer status);
+}

--- a/xiaou-plan/src/main/java/com/xiaou/plan/scheduler/PlanRemindScheduler.java
+++ b/xiaou-plan/src/main/java/com/xiaou/plan/scheduler/PlanRemindScheduler.java
@@ -1,0 +1,202 @@
+package com.xiaou.plan.scheduler;
+
+import com.xiaou.common.domain.Notification;
+import com.xiaou.common.enums.NotificationStatusEnum;
+import com.xiaou.common.service.NotificationService;
+import com.xiaou.plan.domain.PlanRemindTask;
+import com.xiaou.plan.domain.UserPlan;
+import com.xiaou.plan.mapper.PlanRemindTaskMapper;
+import com.xiaou.plan.mapper.UserPlanMapper;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * 计划提醒调度器
+ * 
+ * @author xiaou
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class PlanRemindScheduler {
+    
+    private final UserPlanMapper planMapper;
+    private final PlanRemindTaskMapper remindTaskMapper;
+    private final NotificationService notificationService;
+    
+    /**
+     * 每天凌晨生成当日的提醒任务
+     */
+    @Scheduled(cron = "0 0 0 * * ?")
+    public void generateDailyRemindTasks() {
+        log.info("开始生成当日提醒任务");
+        LocalDate today = LocalDate.now();
+        
+        try {
+            // 查询所有需要提醒的计划
+            List<UserPlan> plans = planMapper.selectPlansForRemind(today);
+            List<PlanRemindTask> tasksToInsert = new ArrayList<>();
+            
+            for (UserPlan plan : plans) {
+                // 检查今天是否已生成提醒任务
+                int existCount = remindTaskMapper.countByPlanIdAndDate(plan.getId(), today);
+                if (existCount > 0) {
+                    continue;
+                }
+                
+                LocalDateTime now = LocalDateTime.now();
+                
+                // 生成开始提醒任务
+                if (plan.getDailyStartTime() != null && plan.getRemindBefore() != null && plan.getRemindBefore() > 0) {
+                    LocalDateTime startRemindTime = LocalDateTime.of(today, plan.getDailyStartTime())
+                            .minusMinutes(plan.getRemindBefore());
+                    
+                    if (startRemindTime.isAfter(now)) {
+                        PlanRemindTask startTask = new PlanRemindTask();
+                        startTask.setPlanId(plan.getId());
+                        startTask.setUserId(plan.getUserId());
+                        startTask.setRemindType(1); // 开始提醒
+                        startTask.setRemindDate(today);
+                        startTask.setRemindTime(startRemindTime);
+                        startTask.setStatus(0); // 待发送
+                        startTask.setCreateTime(now);
+                        tasksToInsert.add(startTask);
+                    }
+                }
+                
+                // 生成截止提醒任务
+                if (plan.getDailyEndTime() != null && plan.getRemindDeadline() != null && plan.getRemindDeadline() > 0) {
+                    LocalDateTime deadlineRemindTime = LocalDateTime.of(today, plan.getDailyEndTime())
+                            .minusMinutes(plan.getRemindDeadline());
+                    
+                    if (deadlineRemindTime.isAfter(now)) {
+                        PlanRemindTask deadlineTask = new PlanRemindTask();
+                        deadlineTask.setPlanId(plan.getId());
+                        deadlineTask.setUserId(plan.getUserId());
+                        deadlineTask.setRemindType(2); // 截止提醒
+                        deadlineTask.setRemindDate(today);
+                        deadlineTask.setRemindTime(deadlineRemindTime);
+                        deadlineTask.setStatus(0); // 待发送
+                        deadlineTask.setCreateTime(now);
+                        tasksToInsert.add(deadlineTask);
+                    }
+                }
+            }
+            
+            // 批量插入提醒任务
+            if (!tasksToInsert.isEmpty()) {
+                remindTaskMapper.batchInsert(tasksToInsert);
+                log.info("生成当日提醒任务完成，共{}个任务", tasksToInsert.size());
+            }
+            
+        } catch (Exception e) {
+            log.error("生成当日提醒任务失败", e);
+        }
+    }
+    
+    /**
+     * 每分钟扫描待发送的提醒任务
+     */
+    @Scheduled(cron = "0 * * * * ?")
+    public void scanAndSendRemindTasks() {
+        LocalDateTime now = LocalDateTime.now();
+        LocalDateTime oneMinuteLater = now.plusMinutes(1);
+        
+        try {
+            // 查询即将到期的提醒任务
+            List<PlanRemindTask> tasks = remindTaskMapper.selectPendingTasks(now, oneMinuteLater);
+            
+            for (PlanRemindTask task : tasks) {
+                sendRemind(task);
+            }
+            
+        } catch (Exception e) {
+            log.error("扫描提醒任务失败", e);
+        }
+    }
+    
+    /**
+     * 发送提醒通知
+     */
+    private void sendRemind(PlanRemindTask task) {
+        try {
+            // 获取计划信息
+            UserPlan plan = planMapper.selectById(task.getPlanId());
+            if (plan == null) {
+                remindTaskMapper.updateStatus(task.getId(), 2, LocalDateTime.now()); // 取消
+                return;
+            }
+            
+            // 构建通知内容
+            String title;
+            String content;
+            if (task.getRemindType() == 1) {
+                // 开始提醒
+                title = "📋 " + plan.getPlanName() + " 即将开始";
+                content = "您的任务「" + plan.getPlanName() + "」将在 " + 
+                        formatTime(plan.getDailyStartTime()) + " 开始，目标：" + 
+                        plan.getTargetValue() + plan.getTargetUnit() + "。加油！";
+            } else {
+                // 截止提醒
+                title = "⏰ " + plan.getPlanName() + " 即将截止";
+                content = "您的任务「" + plan.getPlanName() + "」将在 " + 
+                        formatTime(plan.getDailyEndTime()) + " 截止，还未完成哦~";
+            }
+            
+            // 创建通知
+            Notification notification = new Notification();
+            notification.setTitle(title);
+            notification.setContent(content);
+            notification.setType("SYSTEM");
+            notification.setPriority("NORMAL");
+            notification.setReceiverId(task.getUserId());
+            notification.setSourceModule("plan");
+            notification.setSourceId(String.valueOf(plan.getId()));
+            notification.setStatus(NotificationStatusEnum.UNREAD.getCode());
+            notification.setCreatedTime(LocalDateTime.now());
+            
+            // 发送通知
+            notificationService.sendNotification(notification);
+            
+            // 更新任务状态
+            remindTaskMapper.updateStatus(task.getId(), 1, LocalDateTime.now());
+            
+            log.info("发送计划提醒成功，任务ID：{}，用户ID：{}", task.getId(), task.getUserId());
+            
+        } catch (Exception e) {
+            log.error("发送提醒失败，任务ID：{}", task.getId(), e);
+        }
+    }
+    
+    /**
+     * 格式化时间
+     */
+    private String formatTime(LocalTime time) {
+        if (time == null) {
+            return "";
+        }
+        return String.format("%02d:%02d", time.getHour(), time.getMinute());
+    }
+    
+    /**
+     * 每周清理历史提醒任务
+     */
+    @Scheduled(cron = "0 0 3 ? * MON")
+    public void cleanOldRemindTasks() {
+        try {
+            LocalDate beforeDate = LocalDate.now().minusDays(7);
+            int deleted = remindTaskMapper.deleteOldTasks(beforeDate);
+            log.info("清理历史提醒任务完成，删除{}条记录", deleted);
+        } catch (Exception e) {
+            log.error("清理历史提醒任务失败", e);
+        }
+    }
+}

--- a/xiaou-plan/src/main/java/com/xiaou/plan/service/PlanService.java
+++ b/xiaou-plan/src/main/java/com/xiaou/plan/service/PlanService.java
@@ -1,0 +1,70 @@
+package com.xiaou.plan.service;
+
+import com.xiaou.common.core.domain.PageResult;
+import com.xiaou.plan.domain.PlanCheckinRecord;
+import com.xiaou.plan.dto.*;
+
+import java.util.List;
+
+/**
+ * 计划服务接口
+ * 
+ * @author xiaou
+ */
+public interface PlanService {
+    
+    /**
+     * 创建计划
+     */
+    PlanResponse createPlan(Long userId, PlanCreateRequest request);
+    
+    /**
+     * 更新计划
+     */
+    PlanResponse updatePlan(Long userId, Long planId, PlanCreateRequest request);
+    
+    /**
+     * 删除计划
+     */
+    boolean deletePlan(Long userId, Long planId);
+    
+    /**
+     * 获取计划详情
+     */
+    PlanResponse getPlanDetail(Long userId, Long planId);
+    
+    /**
+     * 获取计划列表
+     */
+    PageResult<PlanResponse> getPlanList(PlanListRequest request);
+    
+    /**
+     * 暂停计划
+     */
+    boolean pausePlan(Long userId, Long planId);
+    
+    /**
+     * 恢复计划
+     */
+    boolean resumePlan(Long userId, Long planId);
+    
+    /**
+     * 获取今日任务列表
+     */
+    List<TodayTaskResponse> getTodayTasks(Long userId);
+    
+    /**
+     * 执行打卡
+     */
+    PlanCheckinResponse checkin(Long userId, PlanCheckinRequest request);
+    
+    /**
+     * 获取计划打卡记录
+     */
+    List<PlanCheckinRecord> getCheckinRecords(Long userId, Long planId);
+    
+    /**
+     * 获取统计概览
+     */
+    PlanStatsResponse getStatsOverview(Long userId);
+}

--- a/xiaou-plan/src/main/java/com/xiaou/plan/service/impl/PlanServiceImpl.java
+++ b/xiaou-plan/src/main/java/com/xiaou/plan/service/impl/PlanServiceImpl.java
@@ -1,0 +1,496 @@
+package com.xiaou.plan.service.impl;
+
+import cn.hutool.core.util.StrUtil;
+import com.xiaou.common.core.domain.PageResult;
+import com.xiaou.common.exception.BusinessException;
+import com.xiaou.common.utils.PageHelper;
+import com.xiaou.plan.domain.PlanCheckinRecord;
+import com.xiaou.plan.domain.UserPlan;
+import com.xiaou.plan.dto.*;
+import com.xiaou.plan.enums.PlanStatus;
+import com.xiaou.plan.enums.PlanType;
+import com.xiaou.plan.enums.RepeatType;
+import com.xiaou.plan.mapper.PlanCheckinRecordMapper;
+import com.xiaou.plan.mapper.UserPlanMapper;
+import com.xiaou.plan.service.PlanService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.DayOfWeek;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.temporal.ChronoUnit;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * 计划服务实现类
+ * 
+ * @author xiaou
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class PlanServiceImpl implements PlanService {
+    
+    private final UserPlanMapper planMapper;
+    private final PlanCheckinRecordMapper checkinRecordMapper;
+    
+    /**
+     * 计划打卡积分
+     */
+    private static final int CHECKIN_POINTS = 10;
+    
+    @Override
+    @Transactional
+    public PlanResponse createPlan(Long userId, PlanCreateRequest request) {
+        // 参数校验
+        if (StrUtil.isBlank(request.getPlanName())) {
+            throw new BusinessException("计划名称不能为空");
+        }
+        if (request.getPlanType() == null) {
+            throw new BusinessException("计划类型不能为空");
+        }
+        if (request.getStartDate() == null) {
+            throw new BusinessException("开始日期不能为空");
+        }
+        
+        // 构建计划实体
+        UserPlan plan = new UserPlan();
+        plan.setUserId(userId);
+        plan.setPlanName(request.getPlanName());
+        plan.setPlanDesc(request.getPlanDesc());
+        plan.setPlanType(request.getPlanType());
+        plan.setTargetType(request.getTargetType() != null ? request.getTargetType() : 1);
+        plan.setTargetValue(request.getTargetValue() != null ? request.getTargetValue() : 1);
+        plan.setTargetUnit(request.getTargetUnit() != null ? request.getTargetUnit() : "次");
+        plan.setStartDate(request.getStartDate());
+        plan.setEndDate(request.getEndDate());
+        plan.setDailyStartTime(request.getDailyStartTime());
+        plan.setDailyEndTime(request.getDailyEndTime());
+        plan.setRepeatType(request.getRepeatType() != null ? request.getRepeatType() : 1);
+        plan.setRepeatDays(request.getRepeatDays());
+        plan.setRemindBefore(request.getRemindBefore() != null ? request.getRemindBefore() : 30);
+        plan.setRemindDeadline(request.getRemindDeadline() != null ? request.getRemindDeadline() : 10);
+        plan.setRemindEnabled(request.getRemindEnabled() != null ? request.getRemindEnabled() : 1);
+        plan.setStatus(PlanStatus.ACTIVE.getCode());
+        plan.setTotalCheckinDays(0);
+        plan.setCurrentStreak(0);
+        plan.setMaxStreak(0);
+        plan.setCreateTime(LocalDateTime.now());
+        plan.setUpdateTime(LocalDateTime.now());
+        
+        planMapper.insert(plan);
+        log.info("用户{}创建计划成功，计划ID：{}", userId, plan.getId());
+        
+        return convertToPlanResponse(plan, LocalDate.now());
+    }
+    
+    @Override
+    @Transactional
+    public PlanResponse updatePlan(Long userId, Long planId, PlanCreateRequest request) {
+        UserPlan plan = planMapper.selectByUserIdAndId(userId, planId);
+        if (plan == null) {
+            throw new BusinessException("计划不存在");
+        }
+        
+        // 更新字段
+        if (StrUtil.isNotBlank(request.getPlanName())) {
+            plan.setPlanName(request.getPlanName());
+        }
+        plan.setPlanDesc(request.getPlanDesc());
+        if (request.getPlanType() != null) {
+            plan.setPlanType(request.getPlanType());
+        }
+        if (request.getTargetType() != null) {
+            plan.setTargetType(request.getTargetType());
+        }
+        if (request.getTargetValue() != null) {
+            plan.setTargetValue(request.getTargetValue());
+        }
+        if (request.getTargetUnit() != null) {
+            plan.setTargetUnit(request.getTargetUnit());
+        }
+        if (request.getStartDate() != null) {
+            plan.setStartDate(request.getStartDate());
+        }
+        plan.setEndDate(request.getEndDate());
+        plan.setDailyStartTime(request.getDailyStartTime());
+        plan.setDailyEndTime(request.getDailyEndTime());
+        if (request.getRepeatType() != null) {
+            plan.setRepeatType(request.getRepeatType());
+        }
+        plan.setRepeatDays(request.getRepeatDays());
+        if (request.getRemindBefore() != null) {
+            plan.setRemindBefore(request.getRemindBefore());
+        }
+        if (request.getRemindDeadline() != null) {
+            plan.setRemindDeadline(request.getRemindDeadline());
+        }
+        if (request.getRemindEnabled() != null) {
+            plan.setRemindEnabled(request.getRemindEnabled());
+        }
+        
+        planMapper.update(plan);
+        log.info("用户{}更新计划成功，计划ID：{}", userId, planId);
+        
+        return convertToPlanResponse(plan, LocalDate.now());
+    }
+    
+    @Override
+    @Transactional
+    public boolean deletePlan(Long userId, Long planId) {
+        int result = planMapper.deleteById(planId, userId);
+        if (result > 0) {
+            log.info("用户{}删除计划成功，计划ID：{}", userId, planId);
+            return true;
+        }
+        return false;
+    }
+    
+    @Override
+    public PlanResponse getPlanDetail(Long userId, Long planId) {
+        UserPlan plan = planMapper.selectByUserIdAndId(userId, planId);
+        if (plan == null) {
+            throw new BusinessException("计划不存在");
+        }
+        return convertToPlanResponse(plan, LocalDate.now());
+    }
+    
+    @Override
+    public PageResult<PlanResponse> getPlanList(PlanListRequest request) {
+        LocalDate today = LocalDate.now();
+        return PageHelper.doPage(request.getPageNum(), request.getPageSize(), () -> {
+            List<UserPlan> plans = planMapper.selectList(request);
+            return plans.stream()
+                    .map(plan -> convertToPlanResponse(plan, today))
+                    .collect(Collectors.toList());
+        });
+    }
+    
+    @Override
+    @Transactional
+    public boolean pausePlan(Long userId, Long planId) {
+        UserPlan plan = planMapper.selectByUserIdAndId(userId, planId);
+        if (plan == null) {
+            throw new BusinessException("计划不存在");
+        }
+        if (plan.getStatus() != PlanStatus.ACTIVE.getCode()) {
+            throw new BusinessException("只有进行中的计划可以暂停");
+        }
+        
+        planMapper.updateStatus(planId, PlanStatus.PAUSED.getCode());
+        log.info("用户{}暂停计划，计划ID：{}", userId, planId);
+        return true;
+    }
+    
+    @Override
+    @Transactional
+    public boolean resumePlan(Long userId, Long planId) {
+        UserPlan plan = planMapper.selectByUserIdAndId(userId, planId);
+        if (plan == null) {
+            throw new BusinessException("计划不存在");
+        }
+        if (plan.getStatus() != PlanStatus.PAUSED.getCode()) {
+            throw new BusinessException("只有已暂停的计划可以恢复");
+        }
+        
+        planMapper.updateStatus(planId, PlanStatus.ACTIVE.getCode());
+        log.info("用户{}恢复计划，计划ID：{}", userId, planId);
+        return true;
+    }
+    
+    @Override
+    public List<TodayTaskResponse> getTodayTasks(Long userId) {
+        LocalDate today = LocalDate.now();
+        LocalTime now = LocalTime.now();
+        
+        List<UserPlan> plans = planMapper.selectTodayPlans(userId, today);
+        List<TodayTaskResponse> tasks = new ArrayList<>();
+        
+        for (UserPlan plan : plans) {
+            // 检查今天是否需要打卡（根据重复规则）
+            if (!shouldCheckinToday(plan, today)) {
+                continue;
+            }
+            
+            // 检查今天是否已打卡
+            PlanCheckinRecord record = checkinRecordMapper.selectByPlanIdAndDate(plan.getId(), today);
+            boolean checkedIn = record != null;
+            
+            // 计算任务状态
+            int taskStatus = 0; // 待完成
+            String taskStatusDesc = "待完成";
+            if (checkedIn) {
+                taskStatus = 1;
+                taskStatusDesc = "已完成";
+            } else if (plan.getDailyEndTime() != null && now.isAfter(plan.getDailyEndTime())) {
+                taskStatus = 2;
+                taskStatusDesc = "已过期";
+            }
+            
+            // 计算剩余时间
+            Long remainingMinutes = null;
+            String remainingTimeDesc = "";
+            if (!checkedIn && plan.getDailyEndTime() != null && now.isBefore(plan.getDailyEndTime())) {
+                remainingMinutes = now.until(plan.getDailyEndTime(), ChronoUnit.MINUTES);
+                if (remainingMinutes >= 60) {
+                    remainingTimeDesc = "剩余 " + (remainingMinutes / 60) + "小时" + (remainingMinutes % 60) + "分";
+                } else {
+                    remainingTimeDesc = "剩余 " + remainingMinutes + "分钟";
+                }
+            }
+            
+            PlanType planType = PlanType.fromCode(plan.getPlanType());
+            
+            tasks.add(TodayTaskResponse.builder()
+                    .planId(plan.getId())
+                    .planName(plan.getPlanName())
+                    .planType(plan.getPlanType())
+                    .planTypeDesc(planType.getDesc())
+                    .planTypeIcon(planType.getIcon())
+                    .targetValue(plan.getTargetValue())
+                    .targetUnit(plan.getTargetUnit())
+                    .dailyStartTime(plan.getDailyStartTime())
+                    .dailyEndTime(plan.getDailyEndTime())
+                    .taskStatus(taskStatus)
+                    .taskStatusDesc(taskStatusDesc)
+                    .checkedIn(checkedIn)
+                    .remainingMinutes(remainingMinutes)
+                    .remainingTimeDesc(remainingTimeDesc)
+                    .currentStreak(plan.getCurrentStreak())
+                    .build());
+        }
+        
+        return tasks;
+    }
+    
+    @Override
+    @Transactional
+    public PlanCheckinResponse checkin(Long userId, PlanCheckinRequest request) {
+        LocalDate today = LocalDate.now();
+        
+        // 查询计划
+        UserPlan plan = planMapper.selectByUserIdAndId(userId, request.getPlanId());
+        if (plan == null) {
+            throw new BusinessException("计划不存在");
+        }
+        if (plan.getStatus() != PlanStatus.ACTIVE.getCode()) {
+            throw new BusinessException("计划未在进行中，无法打卡");
+        }
+        
+        // 检查今天是否已打卡
+        PlanCheckinRecord existingRecord = checkinRecordMapper.selectByPlanIdAndDate(plan.getId(), today);
+        if (existingRecord != null) {
+            throw new BusinessException("今日已打卡，请勿重复操作");
+        }
+        
+        // 检查今天是否需要打卡
+        if (!shouldCheckinToday(plan, today)) {
+            throw new BusinessException("今日不需要打卡");
+        }
+        
+        // 计算连续打卡天数
+        int newStreak = calculateNewStreak(plan, today);
+        int newMaxStreak = Math.max(plan.getMaxStreak(), newStreak);
+        int newTotalDays = plan.getTotalCheckinDays() + 1;
+        
+        // 创建打卡记录
+        PlanCheckinRecord record = new PlanCheckinRecord();
+        record.setPlanId(plan.getId());
+        record.setUserId(userId);
+        record.setCheckinDate(today);
+        record.setCheckinTime(LocalDateTime.now());
+        record.setCompleteValue(request.getCompleteValue());
+        record.setCompleteContent(request.getCompleteContent());
+        record.setRemark(request.getRemark());
+        record.setIsSupplement(0);
+        record.setPointsEarned(CHECKIN_POINTS);
+        record.setCreateTime(LocalDateTime.now());
+        
+        checkinRecordMapper.insert(record);
+        
+        // 更新计划统计
+        planMapper.updateCheckinStats(plan.getId(), newTotalDays, newStreak, newMaxStreak);
+        
+        log.info("用户{}打卡成功，计划ID：{}，连续{}天", userId, plan.getId(), newStreak);
+        
+        return PlanCheckinResponse.builder()
+                .recordId(record.getId())
+                .planId(plan.getId())
+                .planName(plan.getPlanName())
+                .pointsEarned(CHECKIN_POINTS)
+                .currentStreak(newStreak)
+                .totalCheckinDays(newTotalDays)
+                .message("打卡成功！连续打卡 " + newStreak + " 天")
+                .build();
+    }
+    
+    @Override
+    public List<PlanCheckinRecord> getCheckinRecords(Long userId, Long planId) {
+        // 验证计划所属用户
+        UserPlan plan = planMapper.selectByUserIdAndId(userId, planId);
+        if (plan == null) {
+            throw new BusinessException("计划不存在");
+        }
+        return checkinRecordMapper.selectByPlanId(planId);
+    }
+    
+    @Override
+    public PlanStatsResponse getStatsOverview(Long userId) {
+        LocalDate today = LocalDate.now();
+        
+        // 统计进行中计划数
+        int activePlanCount = planMapper.countByUserId(userId, PlanStatus.ACTIVE.getCode());
+        
+        // 统计累计打卡次数
+        int totalCheckinCount = checkinRecordMapper.countByUserId(userId);
+        
+        // 获取所有计划计算最长连续天数
+        List<UserPlan> plans = planMapper.selectActivePlans(userId);
+        int maxStreak = plans.stream()
+                .mapToInt(UserPlan::getMaxStreak)
+                .max()
+                .orElse(0);
+        
+        // 获取今日任务统计
+        List<TodayTaskResponse> todayTasks = getTodayTasks(userId);
+        int todayCompletedCount = (int) todayTasks.stream().filter(TodayTaskResponse::getCheckedIn).count();
+        int todayPendingCount = todayTasks.size() - todayCompletedCount;
+        
+        return PlanStatsResponse.builder()
+                .activePlanCount(activePlanCount)
+                .totalCheckinCount(totalCheckinCount)
+                .avgCompletionRate(0.0) // 简化处理
+                .maxStreak(maxStreak)
+                .weekCheckinCount(0) // 简化处理
+                .monthCheckinCount(0) // 简化处理
+                .todayCompletedCount(todayCompletedCount)
+                .todayPendingCount(todayPendingCount)
+                .build();
+    }
+    
+    /**
+     * 判断今天是否需要打卡
+     */
+    private boolean shouldCheckinToday(UserPlan plan, LocalDate today) {
+        int repeatType = plan.getRepeatType();
+        DayOfWeek dayOfWeek = today.getDayOfWeek();
+        
+        switch (repeatType) {
+            case 1: // 每日
+                return true;
+            case 2: // 工作日
+                return dayOfWeek != DayOfWeek.SATURDAY && dayOfWeek != DayOfWeek.SUNDAY;
+            case 3: // 周末
+                return dayOfWeek == DayOfWeek.SATURDAY || dayOfWeek == DayOfWeek.SUNDAY;
+            case 4: // 自定义
+                if (StrUtil.isBlank(plan.getRepeatDays())) {
+                    return true;
+                }
+                int todayValue = dayOfWeek.getValue(); // 1=周一, 7=周日
+                return Arrays.stream(plan.getRepeatDays().split(","))
+                        .map(String::trim)
+                        .anyMatch(d -> d.equals(String.valueOf(todayValue)));
+            default:
+                return true;
+        }
+    }
+    
+    /**
+     * 计算新的连续打卡天数
+     */
+    private int calculateNewStreak(UserPlan plan, LocalDate today) {
+        PlanCheckinRecord lastRecord = checkinRecordMapper.selectLatestByPlanId(plan.getId());
+        if (lastRecord == null) {
+            return 1; // 首次打卡
+        }
+        
+        LocalDate lastCheckinDate = lastRecord.getCheckinDate();
+        
+        // 检查是否连续（考虑重复规则）
+        LocalDate checkDate = today.minusDays(1);
+        while (!checkDate.isBefore(lastCheckinDate)) {
+            if (shouldCheckinToday(plan, checkDate)) {
+                // 这一天需要打卡
+                if (checkDate.equals(lastCheckinDate)) {
+                    // 上次打卡就是这天，连续
+                    return plan.getCurrentStreak() + 1;
+                } else {
+                    // 中间漏了需要打卡的日子
+                    return 1;
+                }
+            }
+            checkDate = checkDate.minusDays(1);
+        }
+        
+        // 如果走到这里说明两次打卡之间没有需要打卡的日子，视为连续
+        return plan.getCurrentStreak() + 1;
+    }
+    
+    /**
+     * 转换为响应DTO
+     */
+    private PlanResponse convertToPlanResponse(UserPlan plan, LocalDate today) {
+        PlanType planType = PlanType.fromCode(plan.getPlanType());
+        PlanStatus status = PlanStatus.fromCode(plan.getStatus());
+        RepeatType repeatType = RepeatType.fromCode(plan.getRepeatType());
+        
+        // 检查今天是否已打卡
+        PlanCheckinRecord todayRecord = checkinRecordMapper.selectByPlanIdAndDate(plan.getId(), today);
+        boolean todayCheckedIn = todayRecord != null;
+        
+        // 检查今天是否需要打卡
+        boolean todayNeedCheckin = plan.getStatus() == PlanStatus.ACTIVE.getCode() 
+                && shouldCheckinToday(plan, today)
+                && (plan.getEndDate() == null || !today.isAfter(plan.getEndDate()));
+        
+        // 计算完成率
+        Double completionRate = 0.0;
+        if (plan.getStartDate() != null) {
+            LocalDate endDate = plan.getEndDate() != null ? plan.getEndDate() : today;
+            long totalDays = ChronoUnit.DAYS.between(plan.getStartDate(), endDate) + 1;
+            if (totalDays > 0 && plan.getTotalCheckinDays() != null) {
+                completionRate = (double) plan.getTotalCheckinDays() / totalDays * 100;
+            }
+        }
+        
+        return PlanResponse.builder()
+                .id(plan.getId())
+                .userId(plan.getUserId())
+                .planName(plan.getPlanName())
+                .planDesc(plan.getPlanDesc())
+                .planType(plan.getPlanType())
+                .planTypeDesc(planType.getDesc())
+                .planTypeIcon(planType.getIcon())
+                .targetType(plan.getTargetType())
+                .targetValue(plan.getTargetValue())
+                .targetUnit(plan.getTargetUnit())
+                .startDate(plan.getStartDate())
+                .endDate(plan.getEndDate())
+                .dailyStartTime(plan.getDailyStartTime())
+                .dailyEndTime(plan.getDailyEndTime())
+                .repeatType(plan.getRepeatType())
+                .repeatTypeDesc(repeatType.getDesc())
+                .repeatDays(plan.getRepeatDays())
+                .remindBefore(plan.getRemindBefore())
+                .remindDeadline(plan.getRemindDeadline())
+                .remindEnabled(plan.getRemindEnabled())
+                .status(plan.getStatus())
+                .statusDesc(status.getDesc())
+                .totalCheckinDays(plan.getTotalCheckinDays())
+                .currentStreak(plan.getCurrentStreak())
+                .maxStreak(plan.getMaxStreak())
+                .completionRate(completionRate)
+                .todayCheckedIn(todayCheckedIn)
+                .todayNeedCheckin(todayNeedCheckin)
+                .createTime(plan.getCreateTime())
+                .updateTime(plan.getUpdateTime())
+                .build();
+    }
+}

--- a/xiaou-plan/src/main/resources/mapper/PlanCheckinRecordMapper.xml
+++ b/xiaou-plan/src/main/resources/mapper/PlanCheckinRecordMapper.xml
@@ -1,0 +1,89 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+<mapper namespace="com.xiaou.plan.mapper.PlanCheckinRecordMapper">
+
+    <resultMap id="BaseResultMap" type="com.xiaou.plan.domain.PlanCheckinRecord">
+        <id column="id" property="id" jdbcType="BIGINT"/>
+        <result column="plan_id" property="planId" jdbcType="BIGINT"/>
+        <result column="user_id" property="userId" jdbcType="BIGINT"/>
+        <result column="checkin_date" property="checkinDate" jdbcType="DATE"/>
+        <result column="checkin_time" property="checkinTime" jdbcType="TIMESTAMP"/>
+        <result column="complete_value" property="completeValue" jdbcType="INTEGER"/>
+        <result column="complete_content" property="completeContent" jdbcType="VARCHAR"/>
+        <result column="remark" property="remark" jdbcType="VARCHAR"/>
+        <result column="is_supplement" property="isSupplement" jdbcType="TINYINT"/>
+        <result column="points_earned" property="pointsEarned" jdbcType="INTEGER"/>
+        <result column="create_time" property="createTime" jdbcType="TIMESTAMP"/>
+    </resultMap>
+
+    <sql id="Base_Column_List">
+        id, plan_id, user_id, checkin_date, checkin_time, complete_value, complete_content,
+        remark, is_supplement, points_earned, create_time
+    </sql>
+
+    <insert id="insert" useGeneratedKeys="true" keyProperty="id">
+        INSERT INTO plan_checkin_record (
+            plan_id, user_id, checkin_date, checkin_time, complete_value, complete_content,
+            remark, is_supplement, points_earned, create_time
+        ) VALUES (
+            #{planId}, #{userId}, #{checkinDate}, #{checkinTime}, #{completeValue}, #{completeContent},
+            #{remark}, #{isSupplement}, #{pointsEarned}, #{createTime}
+        )
+    </insert>
+
+    <select id="selectByPlanIdAndDate" resultMap="BaseResultMap">
+        SELECT <include refid="Base_Column_List"/>
+        FROM plan_checkin_record
+        WHERE plan_id = #{planId} AND checkin_date = #{checkinDate}
+    </select>
+
+    <select id="selectByPlanId" resultMap="BaseResultMap">
+        SELECT <include refid="Base_Column_List"/>
+        FROM plan_checkin_record
+        WHERE plan_id = #{planId}
+        ORDER BY checkin_date DESC
+    </select>
+
+    <select id="selectByUserIdAndDate" resultMap="BaseResultMap">
+        SELECT <include refid="Base_Column_List"/>
+        FROM plan_checkin_record
+        WHERE user_id = #{userId} AND checkin_date = #{checkinDate}
+    </select>
+
+    <select id="selectByUserId" resultMap="BaseResultMap">
+        SELECT <include refid="Base_Column_List"/>
+        FROM plan_checkin_record
+        WHERE user_id = #{userId}
+        ORDER BY checkin_date DESC, checkin_time DESC
+    </select>
+
+    <select id="countByPlanId" resultType="int">
+        SELECT COUNT(*)
+        FROM plan_checkin_record
+        WHERE plan_id = #{planId}
+    </select>
+
+    <select id="selectLatestByPlanId" resultMap="BaseResultMap">
+        SELECT <include refid="Base_Column_List"/>
+        FROM plan_checkin_record
+        WHERE plan_id = #{planId}
+        ORDER BY checkin_date DESC
+        LIMIT 1
+    </select>
+
+    <select id="selectByUserIdAndMonth" resultMap="BaseResultMap">
+        SELECT <include refid="Base_Column_List"/>
+        FROM plan_checkin_record
+        WHERE user_id = #{userId}
+          AND YEAR(checkin_date) = #{year}
+          AND MONTH(checkin_date) = #{month}
+        ORDER BY checkin_date ASC
+    </select>
+
+    <select id="countByUserId" resultType="int">
+        SELECT COUNT(*)
+        FROM plan_checkin_record
+        WHERE user_id = #{userId}
+    </select>
+
+</mapper>

--- a/xiaou-plan/src/main/resources/mapper/PlanRemindTaskMapper.xml
+++ b/xiaou-plan/src/main/resources/mapper/PlanRemindTaskMapper.xml
@@ -1,0 +1,69 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+<mapper namespace="com.xiaou.plan.mapper.PlanRemindTaskMapper">
+
+    <resultMap id="BaseResultMap" type="com.xiaou.plan.domain.PlanRemindTask">
+        <id column="id" property="id" jdbcType="BIGINT"/>
+        <result column="plan_id" property="planId" jdbcType="BIGINT"/>
+        <result column="user_id" property="userId" jdbcType="BIGINT"/>
+        <result column="remind_type" property="remindType" jdbcType="TINYINT"/>
+        <result column="remind_date" property="remindDate" jdbcType="DATE"/>
+        <result column="remind_time" property="remindTime" jdbcType="TIMESTAMP"/>
+        <result column="status" property="status" jdbcType="TINYINT"/>
+        <result column="send_time" property="sendTime" jdbcType="TIMESTAMP"/>
+        <result column="create_time" property="createTime" jdbcType="TIMESTAMP"/>
+    </resultMap>
+
+    <sql id="Base_Column_List">
+        id, plan_id, user_id, remind_type, remind_date, remind_time, status, send_time, create_time
+    </sql>
+
+    <insert id="insert" useGeneratedKeys="true" keyProperty="id">
+        INSERT INTO plan_remind_task (
+            plan_id, user_id, remind_type, remind_date, remind_time, status, create_time
+        ) VALUES (
+            #{planId}, #{userId}, #{remindType}, #{remindDate}, #{remindTime}, #{status}, #{createTime}
+        )
+    </insert>
+
+    <insert id="batchInsert">
+        INSERT INTO plan_remind_task (plan_id, user_id, remind_type, remind_date, remind_time, status, create_time)
+        VALUES
+        <foreach collection="tasks" item="task" separator=",">
+            (#{task.planId}, #{task.userId}, #{task.remindType}, #{task.remindDate}, #{task.remindTime}, #{task.status}, #{task.createTime})
+        </foreach>
+    </insert>
+
+    <select id="selectPendingTasks" resultMap="BaseResultMap">
+        SELECT <include refid="Base_Column_List"/>
+        FROM plan_remind_task
+        WHERE status = 0
+          AND remind_time &gt;= #{startTime}
+          AND remind_time &lt; #{endTime}
+        ORDER BY remind_time ASC
+    </select>
+
+    <update id="updateStatus">
+        UPDATE plan_remind_task
+        SET status = #{status}, send_time = #{sendTime}
+        WHERE id = #{id}
+    </update>
+
+    <update id="cancelByPlanId">
+        UPDATE plan_remind_task
+        SET status = 2
+        WHERE plan_id = #{planId} AND status = 0
+    </update>
+
+    <select id="countByPlanIdAndDate" resultType="int">
+        SELECT COUNT(*)
+        FROM plan_remind_task
+        WHERE plan_id = #{planId} AND remind_date = #{remindDate}
+    </select>
+
+    <delete id="deleteOldTasks">
+        DELETE FROM plan_remind_task
+        WHERE status = 1 AND remind_date &lt; #{beforeDate}
+    </delete>
+
+</mapper>

--- a/xiaou-plan/src/main/resources/mapper/UserPlanMapper.xml
+++ b/xiaou-plan/src/main/resources/mapper/UserPlanMapper.xml
@@ -1,0 +1,158 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+<mapper namespace="com.xiaou.plan.mapper.UserPlanMapper">
+
+    <resultMap id="BaseResultMap" type="com.xiaou.plan.domain.UserPlan">
+        <id column="id" property="id" jdbcType="BIGINT"/>
+        <result column="user_id" property="userId" jdbcType="BIGINT"/>
+        <result column="plan_name" property="planName" jdbcType="VARCHAR"/>
+        <result column="plan_desc" property="planDesc" jdbcType="VARCHAR"/>
+        <result column="plan_type" property="planType" jdbcType="TINYINT"/>
+        <result column="target_type" property="targetType" jdbcType="TINYINT"/>
+        <result column="target_value" property="targetValue" jdbcType="INTEGER"/>
+        <result column="target_unit" property="targetUnit" jdbcType="VARCHAR"/>
+        <result column="start_date" property="startDate" jdbcType="DATE"/>
+        <result column="end_date" property="endDate" jdbcType="DATE"/>
+        <result column="daily_start_time" property="dailyStartTime" jdbcType="TIME"/>
+        <result column="daily_end_time" property="dailyEndTime" jdbcType="TIME"/>
+        <result column="repeat_type" property="repeatType" jdbcType="TINYINT"/>
+        <result column="repeat_days" property="repeatDays" jdbcType="VARCHAR"/>
+        <result column="remind_before" property="remindBefore" jdbcType="INTEGER"/>
+        <result column="remind_deadline" property="remindDeadline" jdbcType="INTEGER"/>
+        <result column="remind_enabled" property="remindEnabled" jdbcType="TINYINT"/>
+        <result column="status" property="status" jdbcType="TINYINT"/>
+        <result column="total_checkin_days" property="totalCheckinDays" jdbcType="INTEGER"/>
+        <result column="current_streak" property="currentStreak" jdbcType="INTEGER"/>
+        <result column="max_streak" property="maxStreak" jdbcType="INTEGER"/>
+        <result column="create_time" property="createTime" jdbcType="TIMESTAMP"/>
+        <result column="update_time" property="updateTime" jdbcType="TIMESTAMP"/>
+    </resultMap>
+
+    <sql id="Base_Column_List">
+        id, user_id, plan_name, plan_desc, plan_type, target_type, target_value, target_unit,
+        start_date, end_date, daily_start_time, daily_end_time, repeat_type, repeat_days,
+        remind_before, remind_deadline, remind_enabled, status, total_checkin_days,
+        current_streak, max_streak, create_time, update_time
+    </sql>
+
+    <insert id="insert" useGeneratedKeys="true" keyProperty="id">
+        INSERT INTO user_plan (
+            user_id, plan_name, plan_desc, plan_type, target_type, target_value, target_unit,
+            start_date, end_date, daily_start_time, daily_end_time, repeat_type, repeat_days,
+            remind_before, remind_deadline, remind_enabled, status, total_checkin_days,
+            current_streak, max_streak, create_time, update_time
+        ) VALUES (
+            #{userId}, #{planName}, #{planDesc}, #{planType}, #{targetType}, #{targetValue}, #{targetUnit},
+            #{startDate}, #{endDate}, #{dailyStartTime}, #{dailyEndTime}, #{repeatType}, #{repeatDays},
+            #{remindBefore}, #{remindDeadline}, #{remindEnabled}, #{status}, #{totalCheckinDays},
+            #{currentStreak}, #{maxStreak}, #{createTime}, #{updateTime}
+        )
+    </insert>
+
+    <update id="update">
+        UPDATE user_plan SET
+            plan_name = #{planName},
+            plan_desc = #{planDesc},
+            plan_type = #{planType},
+            target_type = #{targetType},
+            target_value = #{targetValue},
+            target_unit = #{targetUnit},
+            start_date = #{startDate},
+            end_date = #{endDate},
+            daily_start_time = #{dailyStartTime},
+            daily_end_time = #{dailyEndTime},
+            repeat_type = #{repeatType},
+            repeat_days = #{repeatDays},
+            remind_before = #{remindBefore},
+            remind_deadline = #{remindDeadline},
+            remind_enabled = #{remindEnabled},
+            update_time = NOW()
+        WHERE id = #{id} AND user_id = #{userId}
+    </update>
+
+    <select id="selectById" resultMap="BaseResultMap">
+        SELECT <include refid="Base_Column_List"/>
+        FROM user_plan
+        WHERE id = #{id} AND status != 0
+    </select>
+
+    <select id="selectByUserIdAndId" resultMap="BaseResultMap">
+        SELECT <include refid="Base_Column_List"/>
+        FROM user_plan
+        WHERE user_id = #{userId} AND id = #{id} AND status != 0
+    </select>
+
+    <select id="selectList" resultMap="BaseResultMap">
+        SELECT <include refid="Base_Column_List"/>
+        FROM user_plan
+        WHERE user_id = #{userId} AND status != 0
+        <if test="status != null">
+            AND status = #{status}
+        </if>
+        <if test="planType != null">
+            AND plan_type = #{planType}
+        </if>
+        <if test="keyword != null and keyword != ''">
+            AND plan_name LIKE CONCAT('%', #{keyword}, '%')
+        </if>
+        ORDER BY create_time DESC
+    </select>
+
+    <select id="selectTodayPlans" resultMap="BaseResultMap">
+        SELECT <include refid="Base_Column_List"/>
+        FROM user_plan
+        WHERE user_id = #{userId}
+          AND status = 1
+          AND start_date &lt;= #{today}
+          AND (end_date IS NULL OR end_date &gt;= #{today})
+        ORDER BY daily_start_time ASC, create_time DESC
+    </select>
+
+    <select id="selectActivePlans" resultMap="BaseResultMap">
+        SELECT <include refid="Base_Column_List"/>
+        FROM user_plan
+        WHERE user_id = #{userId} AND status = 1
+        ORDER BY create_time DESC
+    </select>
+
+    <update id="updateStatus">
+        UPDATE user_plan SET status = #{status}, update_time = NOW()
+        WHERE id = #{id}
+    </update>
+
+    <update id="updateCheckinStats">
+        UPDATE user_plan SET
+            total_checkin_days = #{totalCheckinDays},
+            current_streak = #{currentStreak},
+            max_streak = #{maxStreak},
+            update_time = NOW()
+        WHERE id = #{id}
+    </update>
+
+    <update id="deleteById">
+        UPDATE user_plan SET status = 0, update_time = NOW()
+        WHERE id = #{id} AND user_id = #{userId}
+    </update>
+
+    <select id="selectPlansForRemind" resultMap="BaseResultMap">
+        SELECT <include refid="Base_Column_List"/>
+        FROM user_plan
+        WHERE status = 1
+          AND remind_enabled = 1
+          AND start_date &lt;= #{today}
+          AND (end_date IS NULL OR end_date &gt;= #{today})
+    </select>
+
+    <select id="countByUserId" resultType="int">
+        SELECT COUNT(*)
+        FROM user_plan
+        WHERE user_id = #{userId}
+        <if test="status != null">
+            AND status = #{status}
+        </if>
+        <if test="status == null">
+            AND status != 0
+        </if>
+    </select>
+
+</mapper>


### PR DESCRIPTION
- 🆕 **计划打卡模块**：`xiaou-plan` 支持个人计划创建、每日打卡、连续打卡统计、站内提醒通知、打卡记录查询等功能。
- 🎨 **首页重新设计**：采用现代卡片式布局，新增 Hero 区域、核心功能展示、快速入口网格、特色亮点区域，提升视觉体验。
- 📱 **面试详情页优化**：优化移动端适配与样式细节，提升手机端刷题体验。
- 🗄️ **数据库脚本**：`sql/v1.6.1` 新增计划打卡相关表结构（user_plan、plan_checkin_record、plan_remind_task）。
- 🔔 **定时任务**：计划模块集成提醒调度器，支持每日任务生成与站内通知推送。
- 🔧 **导航优化**：首页快速入口新增「计划打卡」，顶部导航「学习」菜单新增入口。
