### PR TITLE
fix(deploy): refresh frontend dependencies on every release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -173,7 +173,10 @@ jobs:
         run: python -m py_compile scripts/deploy-frontends.py scripts/you_deserve_to_interview_sql.py
 
       - name: Shell syntax check
-        run: bash -n scripts/deploy-release.sh
+        run: bash -n scripts/ci-server-build-deploy.sh scripts/ci-server-build-deploy.test.sh scripts/deploy-release.sh
+
+      - name: Deployment dependency refresh contract
+        run: bash scripts/ci-server-build-deploy.test.sh
 
   ci-summary:
     name: CI Summary

--- a/scripts/ci-server-build-deploy.sh
+++ b/scripts/ci-server-build-deploy.sh
@@ -39,6 +39,17 @@ copy_tree() {
   cp -a "$source_dir"/. "$target_dir"/
 }
 
+install_frontend_dependencies() {
+  local frontend_dir="$1"
+
+  npm ci \
+    --prefer-offline \
+    --no-audit \
+    --fund=false \
+    --ignore-scripts \
+    --prefix "$frontend_dir"
+}
+
 main() {
   require_cmd git
   require_cmd mvn
@@ -64,16 +75,14 @@ main() {
   log "build backend"
   mvn -B -pl xiaou-application -am clean package -DskipTests
 
+  log "install admin frontend dependencies"
+  install_frontend_dependencies vue3-admin-front
   log "build admin frontend"
-  if [[ ! -d vue3-admin-front/node_modules ]]; then
-    npm ci --prefer-offline --no-audit --fund=false --ignore-scripts --timeout=300000 --prefix vue3-admin-front
-  fi
   npm run build --prefix vue3-admin-front
 
+  log "install user frontend dependencies"
+  install_frontend_dependencies vue3-user-front
   log "build user frontend"
-  if [[ ! -d vue3-user-front/node_modules ]]; then
-    npm ci --prefer-offline --no-audit --fund=false --ignore-scripts --timeout=300000 --prefix vue3-user-front
-  fi
   npm run build --prefix vue3-user-front
 
   log "assemble release bundle"
@@ -105,4 +114,6 @@ EOF
     "$bundle"
 }
 
-main "$@"
+if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
+  main "$@"
+fi

--- a/scripts/ci-server-build-deploy.test.sh
+++ b/scripts/ci-server-build-deploy.test.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+source "$repo_root/scripts/ci-server-build-deploy.sh"
+
+declare -a npm_calls=()
+
+npm() {
+  npm_calls+=("$*")
+}
+
+workspace="$(mktemp -d)"
+trap 'rm -rf "$workspace"' EXIT
+mkdir -p \
+  "$workspace/vue3-admin-front/node_modules" \
+  "$workspace/vue3-user-front/node_modules"
+
+cd "$workspace"
+install_frontend_dependencies vue3-admin-front
+install_frontend_dependencies vue3-user-front
+
+if [[ "${#npm_calls[@]}" -ne 2 ]]; then
+  printf 'expected npm ci for both frontends, got %s calls\n' "${#npm_calls[@]}" >&2
+  exit 1
+fi
+
+for call in "${npm_calls[@]}"; do
+  if [[ "$call" != ci\ * ]]; then
+    printf 'expected npm ci, got: npm %s\n' "$call" >&2
+    exit 1
+  fi
+done
+
+for frontend_dir in vue3-admin-front vue3-user-front; do
+  if ! printf '%s\n' "${npm_calls[@]}" | grep -Fq -- "--prefix $frontend_dir"; then
+    printf 'missing npm ci call for %s\n' "$frontend_dir" >&2
+    exit 1
+  fi
+done
+
+printf 'deployment dependency refresh contract passed\n'

--- a/scripts/code-nest-eval.ps1
+++ b/scripts/code-nest-eval.ps1
@@ -344,7 +344,9 @@ function Invoke-Release {
 
     Invoke-Step "script syntax checks" {
         Invoke-Native -Command $PythonCommand -Arguments @("-m", "py_compile", "scripts/deploy-frontends.py", "scripts/you_deserve_to_interview_sql.py")
-        Invoke-Native -Command (Resolve-BashCommand) -Arguments @("-n", "scripts/deploy-release.sh")
+        $bash = Resolve-BashCommand
+        Invoke-Native -Command $bash -Arguments @("-n", "scripts/ci-server-build-deploy.sh", "scripts/ci-server-build-deploy.test.sh", "scripts/deploy-release.sh")
+        Invoke-Native -Command $bash -Arguments @("scripts/ci-server-build-deploy.test.sh")
     }
 }
 


### PR DESCRIPTION
## Summary

- always run deterministic `npm ci` for both frontends during production releases
- remove the stale-`node_modules` shortcut that skipped newly added local packages
- add a shell regression contract and include both deployment scripts in syntax checks

## Root Cause

The self-hosted production runner intentionally preserves frontend `node_modules`. The deployment script only installed dependencies when that directory was absent, so v2.4.1 did not install the new `file:../code-nest-design-system` package.

## Verification

- `bash -n scripts/ci-server-build-deploy.sh scripts/ci-server-build-deploy.test.sh scripts/deploy-release.sh`
- `bash scripts/ci-server-build-deploy.test.sh`
- `./scripts/code-nest-eval.ps1 -Tier hygiene`
- production runner admin and user builds passed as the `actions-runner` user
- v2.4.1 production deployment attempt 3 completed successfully