### PR TITLE
fix(sre): wire secure Alertmanager webhook deployment

### DIFF
--- a/AI-DOCS/Technical/SRE/Code-Nest-24x7-SRE-方案.md
+++ b/AI-DOCS/Technical/SRE/Code-Nest-24x7-SRE-方案.md
@@ -127,9 +127,9 @@ flowchart LR
 | --- | --- | --- |
 | 80, 81 | 用户端和管理端 Nginx | 按现有业务需要开放 |
 | 9999 | Spring Boot 后端 | 不开放；由 Nginx 和本机监控访问 |
-| 9090 | Prometheus UI/API | 仅 `127.0.0.1` 或 SSH 隧道 |
+| 19090 | Prometheus UI/API | 仅 `127.0.0.1` 或 SSH 隧道 |
 | 3000 | Grafana | 仅 `127.0.0.1` 或认证反代 |
-| 9093, 9100, 9115 | Alertmanager、node-exporter、blackbox-exporter | 不映射公网端口 |
+| 19093, 19094, 19100, 19115 | Alertmanager、集群通信、node-exporter、blackbox-exporter | 仅 `127.0.0.1` |
 
 `/api/actuator/` 已在 Nginx 上拒绝访问，但这**不能**保护直接暴露的 `9999`。腾讯云
 安全组和服务器防火墙必须同时不允许互联网访问 TCP 9999；否则 Prometheus 指标、JVM
@@ -196,8 +196,8 @@ GC、数据库容量和可接受延迟调参。Google SRE 对告警的建议也�
 ### 7.1 上线前检查
 
 1. 在云安全组中确认只开放业务需要的 `80/81`（以及你自己的 SSH 管理端口），不开放
-   `9999/3000/9090/9093/9100/9115`。
-2. 在服务器确认 Docker Compose v2 可用，磁盘至少留出 Prometheus 30 天数据和 Grafana
+   `9999/3000/19090/19093/19094/19100/19115`。
+2. 在服务器确认 Docker Compose v2 或 Podman Compose 可用，磁盘至少留出 Prometheus 30 天数据和 Grafana
    数据卷的空间。
 3. 本机确认应用可访问：`curl -fsS http://127.0.0.1:9999/api/actuator/health`。
 4. 确认 Nginx 生效后公网 `/api/actuator/health` 返回 404，而正常业务 API 仍可用。
@@ -213,13 +213,16 @@ cp targets/code-nest.local.yml.example targets/code-nest.local.yml
 cp targets/blackbox.local.yml.example targets/blackbox.local.yml
 cp alertmanager/alertmanager.yml.example alertmanager/alertmanager.local.yml
 mkdir -p secrets
-chmod 700 secrets
+: > secrets/sre_webhook_token
+chown 65534:65534 secrets/sre_webhook_token
+chmod 400 secrets/sre_webhook_token
+chmod 711 secrets
 ```
 
 然后完成以下人工配置：
 
-1. 将 `targets/code-nest.local.yml` 的目标设为监控 Docker 网络可达的应用地址；宿主机
-   Java 进程默认是 `host.docker.internal:9999`。
+1. 监控服务使用 Linux host network 访问 loopback，保持
+   `targets/code-nest.local.yml` 的默认目标 `127.0.0.1:9999`。
 2. 将 `targets/blackbox.local.yml` 改成真实的公网 HTTPS URL，优先使用域名而非裸 IP。
 3. 在 `alertmanager.local.yml` 填 QQ 发件箱和收件箱。
 4. 将 QQ SMTP 授权码写入 `secrets/qq_smtp_auth_code`，并设置 `600` 权限。
@@ -229,13 +232,13 @@ chmod 700 secrets
 之后执行：
 
 ```bash
-chmod +x scripts/validate-config.sh
+chmod +x scripts/validate-config.sh scripts/compose.sh
 ./scripts/validate-config.sh
-docker compose --env-file .env up -d
-docker compose --env-file .env ps
+./scripts/compose.sh --env-file .env up -d
+./scripts/compose.sh --env-file .env ps
 ```
 
-`validate-config.sh` 会调用镜像内的 `promtool`、`amtool` 和 `docker compose config`。
+`validate-config.sh` 会调用镜像内的 `promtool`、`amtool` 和实际可用的 Compose 实现。
 它应在真实 Linux 服务器上执行，因为本地 Windows 工作区没有 Docker 和 Nginx 可供运行。
 
 ### 7.3 首次验收演练
@@ -247,7 +250,7 @@ docker compose --env-file .env ps
    resolved 邮件。
 4. 从手机流量或另一台独立网络访问公网 URL，确认页面可达。不要把本机 blackbox 成功
    当成异地可用性证明。
-5. 检查 `docker compose logs`、Prometheus 告警状态和 Grafana 数据源，记录验收时间与结果。
+5. 检查 `./scripts/compose.sh --env-file .env logs`、Prometheus 告警状态和 Grafana 数据源，记录验收时间与结果。
 
 ## 8. P1：完整可观测性基线
 

--- a/AI-DOCS/Technical/SRE/Code-Nest-SRE-技术架构.md
+++ b/AI-DOCS/Technical/SRE/Code-Nest-SRE-技术架构.md
@@ -234,14 +234,15 @@ node-exporter --------------------+
 | 80 | Nginx 用户端 | 公网 | 业务网站和 API。 |
 | 81 | Nginx 管理端 | 公网或办公网 | 后台管理入口。 |
 | 9999 | Spring Boot | 本机/监控网络 | 云安全组禁止互联网访问。 |
-| 9090 | Prometheus | `127.0.0.1` | 使用 SSH 隧道查看。 |
+| 19090 | Prometheus | `127.0.0.1` | 使用 SSH 隧道查看；避开 Cockpit 的 9090。 |
 | 3000 | Grafana | `127.0.0.1` | 使用 SSH 隧道或认证反代。 |
-| 9093 | Alertmanager | Docker bridge | 不映射主机端口。 |
-| 9100 | node-exporter | Docker bridge | 不映射主机端口。 |
-| 9115 | blackbox-exporter | Docker bridge | 不映射主机端口。 |
+| 19093 | Alertmanager | `127.0.0.1` | host network 下仅本机监听。 |
+| 19094 | Alertmanager 集群通信 | `127.0.0.1` | 单机运行时不对外开放。 |
+| 19100 | node-exporter | `127.0.0.1` | host network 下仅本机监听。 |
+| 19115 | blackbox-exporter | `127.0.0.1` | host network 下仅本机监听。 |
 
-Nginx 的 `/api/actuator/` 404 规则是应用层防护；云安全组、服务器防火墙和 Docker 网络
-限制是网络层防护，三层不能只依赖其中一层。
+Nginx 的 `/api/actuator/` 404 规则是应用层防护；云安全组、服务器防火墙和各监控服务的
+loopback 监听是网络层防护，三层不能只依赖其中一层。
 
 ### 5.3 P0 告警生命周期
 
@@ -645,9 +646,9 @@ Grafana 链接使用后端生成的白名单 URL，避免用户输入任意 URL 
 
 - 所有 Prometheus targets 为 `UP`；
 - QQ firing/resolved 邮件均收到；
-- 公网无法访问 `9999`、`9090`、`3000`；
+- 公网无法访问 `9999`、`19090`、`19093`、`19094`、`19100`、`19115`、`3000`；
 - 停止应用可以触发告警，恢复应用可以收到 resolved；
-- 服务器执行过 `promtool`、`amtool`、`docker compose config` 和 Nginx 配置检查。
+- 服务器执行过 `promtool`、`amtool`、Docker/Podman Compose 配置和 Nginx 配置检查。
 
 ### P1：可观测性补全
 
@@ -748,7 +749,7 @@ Docker、任意 PromQL/LogQL 或数据库写操作。
 
 ### 安全
 
-- [ ] 公网无法访问 `9999`、`9090`、`3000`、`9093`、`9100`、`9115`。
+- [ ] 公网无法访问 `9999`、`19090`、`19093`、`19094`、`19100`、`19115`、`3000`。
 - [ ] `/api/actuator/**` 经 Nginx 返回 404。
 - [ ] webhook 使用机器凭据，不使用浏览器 Token。
 - [ ] P1 exporter 使用最小权限账号。

--- a/AI-DOCS/Technical/SRE/code-nest-sre-target-architecture.drawio
+++ b/AI-DOCS/Technical/SRE/code-nest-sre-target-architecture.drawio
@@ -28,7 +28,7 @@
         <mxCell id="p0-nginx" value="Nginx&#xa;80 用户端 / 81 管理端&#xa;拒绝 /api/actuator/*" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#d5e8d4;strokeColor=#82b366;fontColor=#1f2937;fontSize=12;" vertex="1" parent="p0-web-zone">
           <mxGeometry x="45" y="60" width="160" height="90" as="geometry" />
         </mxCell>
-        <mxCell id="p0-firewall" value="云安全组 + 主机防火墙&#xa;9999 / 3000 / 9090 不公网开放" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#f8cecc;strokeColor=#b85450;fontColor=#1f2937;fontSize=11;" vertex="1" parent="p0-web-zone">
+        <mxCell id="p0-firewall" value="云安全组 + 主机防火墙&#xa;9999 / 3000 / 19090+ 不公网开放" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#f8cecc;strokeColor=#b85450;fontColor=#1f2937;fontSize=11;" vertex="1" parent="p0-web-zone">
           <mxGeometry x="30" y="175" width="190" height="60" as="geometry" />
         </mxCell>
 
@@ -57,11 +57,11 @@
         <mxCell id="p0-redis" value="Redis&#xa;Token / 缓存&#xa;分布式锁" style="shape=cylinder3;whiteSpace=wrap;html=1;fillColor=#fff2cc;strokeColor=#d6b656;fontColor=#1f2937;fontSize=12;" vertex="1" parent="p0-data-zone">
           <mxGeometry x="230" y="70" width="130" height="90" as="geometry" />
         </mxCell>
-        <mxCell id="p0-secrets" value="Docker secrets&#xa;QQ 授权码&#xa;本地配置不入 Git" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#f8cecc;strokeColor=#b85450;fontColor=#1f2937;fontSize=12;" vertex="1" parent="p0-data-zone">
+        <mxCell id="p0-secrets" value="本机只读密钥挂载&#xa;QQ 授权码&#xa;UID 65534 / 不入 Git" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#f8cecc;strokeColor=#b85450;fontColor=#1f2937;fontSize=12;" vertex="1" parent="p0-data-zone">
           <mxGeometry x="385" y="75" width="115" height="80" as="geometry" />
         </mxCell>
 
-        <mxCell id="p0-monitor-zone" value="监控网络（Docker bridge，当前与生产机同故障域）" style="swimlane;startSize=28;fillColor=#fce4ec;strokeColor=#b85450;fontColor=#1f2937;fontStyle=1;fontSize=13;html=1;" vertex="1" parent="p0-server">
+        <mxCell id="p0-monitor-zone" value="监控进程（Linux host network，当前与生产机同故障域）" style="swimlane;startSize=28;fillColor=#fce4ec;strokeColor=#b85450;fontColor=#1f2937;fontStyle=1;fontSize=13;html=1;" vertex="1" parent="p0-server">
           <mxGeometry x="30" y="340" width="1370" height="560" as="geometry" />
         </mxCell>
         <mxCell id="p0-node" value="node-exporter&#xa;主机 CPU / 磁盘" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#fce4ec;strokeColor=#b85450;fontColor=#1f2937;fontSize=12;" vertex="1" parent="p0-monitor-zone">

--- a/docker/monitoring/.env.example
+++ b/docker/monitoring/.env.example
@@ -1,18 +1,31 @@
 # Copy to .env on the server. Keep .env and all files in secrets/ out of git.
 COMPOSE_PROJECT_NAME=code-nest-monitoring
 
-PROMETHEUS_IMAGE=prom/prometheus:v3.13.1
-ALERTMANAGER_IMAGE=prom/alertmanager:v0.33.1
-GRAFANA_IMAGE=grafana/grafana:12.3.8
-NODE_EXPORTER_IMAGE=prom/node-exporter:v1.12.1
-BLACKBOX_EXPORTER_IMAGE=prom/blackbox-exporter:v0.28.0
+# The current production server can reach this registry mirror. Replace these
+# with the corresponding official registry paths only after verifying pulls in
+# the target environment.
+PROMETHEUS_IMAGE=docker.1panel.live/prom/prometheus:v3.13.1
+ALERTMANAGER_IMAGE=docker.1panel.live/prom/alertmanager:v0.33.1
+GRAFANA_IMAGE=docker.1panel.live/grafana/grafana:12.3.8
+NODE_EXPORTER_IMAGE=docker.1panel.live/prom/node-exporter:v1.12.1
+BLACKBOX_EXPORTER_IMAGE=docker.1panel.live/prom/blackbox-exporter:v0.28.0
 
-# Bind local-only by default. Use an authenticated reverse proxy or SSH tunnel for access.
+# The Linux monitoring stack uses host networking to reach the Java process bound
+# to 127.0.0.1. Every monitoring endpoint remains bound to loopback.
 PROMETHEUS_BIND_ADDRESS=127.0.0.1
-PROMETHEUS_PORT=9090
+# 9090 is occupied by Cockpit on the current production host. Keep the monitoring
+# API local-only and use a non-conflicting port there.
+PROMETHEUS_PORT=19090
 PROMETHEUS_RETENTION=30d
+ALERTMANAGER_BIND_ADDRESS=127.0.0.1
+ALERTMANAGER_PORT=19093
+ALERTMANAGER_CLUSTER_PORT=19094
 GRAFANA_BIND_ADDRESS=127.0.0.1
 GRAFANA_PORT=3000
 GRAFANA_ROOT_URL=http://localhost:3000
 GRAFANA_ADMIN_USER=admin
 GRAFANA_ADMIN_PASSWORD=change-this-before-starting
+NODE_EXPORTER_BIND_ADDRESS=127.0.0.1
+NODE_EXPORTER_PORT=19100
+BLACKBOX_EXPORTER_BIND_ADDRESS=127.0.0.1
+BLACKBOX_EXPORTER_PORT=19115

--- a/docker/monitoring/README.md
+++ b/docker/monitoring/README.md
@@ -13,21 +13,25 @@ containers, alter databases, or execute AI-proposed actions.
 - HTTP error ratio, latency, and JVM heap
 - QQ mail delivery for warning and critical alerts
 
-MySQL/Redis exporters, logs, traces, incident workflow, and AI RCA belong to
-later phases. Do not add their credentials to this stack until dedicated
-least-privilege accounts and retention policies exist.
+MySQL/Redis exporters, logs, and traces belong to later phases. Do not add
+their credentials to this stack until dedicated least-privilege accounts and
+retention policies exist. The optional SRE webhook records incidents and
+collects read-only evidence; it does not execute repairs.
 
 ## Network Boundary
 
-Before starting, close public access to TCP `9999`, `3000`, `9090`, `9093`,
-`9100`, and `9115` in the cloud security group and host firewall. The public
-entry points are Nginx on `80` and `81`; Nginx proxies business traffic to the
-backend, while Prometheus reaches the backend through Docker's host gateway.
+The production stack uses Linux host networking so it can scrape the Java
+process that intentionally listens only on `127.0.0.1:9999`. Every monitoring
+service explicitly listens on loopback: Prometheus `19090`, Alertmanager
+`19093` and `19094`, node-exporter `19100`, blackbox-exporter `19115`, and
+Grafana `3000`. Do not expose those ports in the cloud security group or host
+firewall. The public entry points remain Nginx on `80` and `81`.
 
 Blocking `/api/actuator/` in Nginx is only one layer. It does not protect a
 directly exposed backend port. Verify that the server's security group does
 not allow public TCP `9999`, and keep the monitoring UI ports bound to
-`127.0.0.1` as configured in `.env`.
+`127.0.0.1` as configured in `.env`. The production host already uses `9090`
+for Cockpit, so `.env.example` selects local-only `19090` for Prometheus.
 
 ## Server Setup
 
@@ -39,13 +43,22 @@ cp targets/code-nest.local.yml.example targets/code-nest.local.yml
 cp targets/blackbox.local.yml.example targets/blackbox.local.yml
 cp alertmanager/alertmanager.yml.example alertmanager/alertmanager.local.yml
 mkdir -p secrets
-chmod 700 secrets
+: > secrets/sre_webhook_token
+chown 65534:65534 secrets/sre_webhook_token
+chmod 400 secrets/sre_webhook_token
+chmod 711 secrets
 ```
 
+The checked-in `.env.example` uses the registry mirror already reachable from
+the production server. Verify any replacement registry before starting the
+stack; a failed image pull must not be discovered during an incident.
+
 Edit the two target files and the local Alertmanager file. `code-nest.local.yml`
-must point at the application metrics endpoint from the monitoring Docker
-network. For a host-exposed application, `host.docker.internal:9999` is the
-default; Docker Compose maps that name to the Linux host gateway.
+must point at the application metrics endpoint on loopback. The default
+`127.0.0.1:9999` is deliberate: bridge networking cannot reach an application
+that only binds loopback, while host networking can. This monitoring setup is
+for Linux hosts; do not use this host-network composition unchanged on Docker
+Desktop.
 
 Set the QQ mailbox and recipient in `alertmanager/alertmanager.local.yml`, then
 write the QQ SMTP authorization code to the secret file without placing it in
@@ -55,37 +68,63 @@ shell history:
 read -rsp 'QQ SMTP authorization code: ' code
 printf '%s' "$code" > secrets/qq_smtp_auth_code
 unset code
-chmod 600 secrets/qq_smtp_auth_code alertmanager/alertmanager.local.yml .env
+chown 65534:65534 secrets/qq_smtp_auth_code
+chmod 400 secrets/qq_smtp_auth_code
+chmod 600 .env
+chmod 644 alertmanager/alertmanager.local.yml
 ```
 
 Use QQ SMTP authorization code rather than the mailbox login password. The
 authorization code and local config are ignored by git.
 
+Alertmanager runs as UID `65534`. The two secret files are mounted individually
+and must remain owned by `65534:65534` with mode `0400`; the directory is
+traversable but not listable. Do not replace these protections with `644`.
+
 ## Validate And Start
 
 ```bash
 chmod +x scripts/validate-config.sh
+chmod +x scripts/compose.sh
 ./scripts/validate-config.sh
-docker compose --env-file .env up -d
-docker compose --env-file .env ps
+./scripts/compose.sh --env-file .env up -d
+./scripts/compose.sh --env-file .env ps
 ```
 
 Prometheus and Grafana bind to `127.0.0.1` by default. Access them through an
-SSH tunnel or an authenticated reverse proxy; do not expose ports 9090 or 3000
-directly to the public internet.
+SSH tunnel or an authenticated reverse proxy; do not expose their configured
+ports directly to the public internet.
 
 ## First Acceptance Drill
 
-1. Confirm all Prometheus targets are `UP`.
-2. Trigger a test alert with the Alertmanager UI/API only after the QQ sender is configured.
-3. Stop the application in a staging window and verify `CodeNestTargetDown` and the public probe alert arrive once, then resolve after recovery.
-4. Restore the application and confirm the resolved email arrives.
+1. Confirm the monitoring API is ready and all Prometheus targets are `UP`:
+
+   ```bash
+   curl --fail --silent --show-error http://127.0.0.1:19090/-/ready
+   curl --fail --silent --show-error http://127.0.0.1:19090/api/v1/targets
+   ```
+
+2. Trigger a named synthetic alert without stopping the only production app:
+
+   ```bash
+   ./scripts/compose.sh --env-file .env exec alertmanager \
+     amtool --alertmanager.url=http://127.0.0.1:19093 alert add \
+     alertname=CodeNestSreE2E severity=warning service=code-nest instance=acceptance
+   ```
+
+   The QQ recipient should receive one firing email after the configured
+   `group_wait` period. Record its Alertmanager fingerprint, expire it with
+   `amtool alert expire <fingerprint>`, and verify the resolved email.
+
+3. When the optional SRE webhook is enabled, verify the same synthetic alert
+   creates exactly one incident and its evidence through the administrator API.
+   Repeat the alert once to verify that the fingerprint is deduplicated.
 
 ## Operational Notes
 
 - Alert thresholds are intentionally conservative starting points. Tune them after two weeks of baseline data.
 - A stack on the same server cannot detect complete server loss. Add an external uptime monitor or a second monitoring node before claiming host-level 24x7 coverage.
-- Nginx now rejects `/api/actuator/`; Prometheus must scrape the backend directly over the host/Docker monitoring path.
+- Nginx now rejects `/api/actuator/`; Prometheus scrapes the backend directly over host loopback.
 
 ## Optional SRE Event Ingestion
 
@@ -95,9 +134,31 @@ not depend on them. Before enabling the worker on the application server:
 1. Apply `sql/v2.5.0/sre_incident.sql`, or apply the incremental
    `sql/v2.5.0/sre_incident_evidence.sql` when the four original SRE tables already exist.
 2. Set a dedicated `XIAOU_SRE_WEBHOOK_TOKEN`; do not reuse an administrator token.
-3. Enable `XIAOU_SRE_WEBHOOK_ENABLED=true` only after the Alertmanager receiver is
+   Put the identical value in `secrets/sre_webhook_token` with owner `65534:65534`
+   and mode `0400`.
+3. Replace the email-only local config with the webhook template, then edit the
+   QQ sender and recipient values:
+
+   ```bash
+   cp alertmanager/alertmanager.sre-webhook.yml.example alertmanager/alertmanager.local.yml
+   read -rsp 'SRE webhook token: ' token
+   printf '%s' "$token" > secrets/sre_webhook_token
+   unset token
+   chown 65534:65534 secrets/sre_webhook_token
+   chmod 400 secrets/sre_webhook_token
+   chmod 644 alertmanager/alertmanager.local.yml
+   ```
+
+   The template sends every alert independently to QQ and the private Java
+   endpoint `http://127.0.0.1:9999/api/internal/sre/alertmanager/v1/alerts`.
+   Do not publish that path through Nginx or the public firewall.
+4. Enable `XIAOU_SRE_WEBHOOK_ENABLED=true` only after the Alertmanager receiver is
    configured to call the backend directly over the monitoring path.
-4. Enable `XIAOU_SRE_OUTBOX_ENABLED=true` only after the evidence table migration succeeds.
+5. Enable `XIAOU_SRE_OUTBOX_ENABLED=true` only after the evidence table migration succeeds.
+
+For Prometheus evidence on the current production host, set
+`XIAOU_SRE_PROMETHEUS_ENDPOINT=http://127.0.0.1:19090` in the application
+environment before enabling `XIAOU_SRE_PROMETHEUS_ENABLED=true`.
 
 The first worker stores an `ALERT_SNAPSHOT` evidence record and can optionally collect
 read-only Prometheus/Loki evidence. Prometheus and Loki are disabled by default in the

--- a/docker/monitoring/alertmanager/alertmanager.sre-webhook.yml.example
+++ b/docker/monitoring/alertmanager/alertmanager.sre-webhook.yml.example
@@ -1,0 +1,47 @@
+global:
+  resolve_timeout: 5m
+  smtp_smarthost: smtp.qq.com:465
+  smtp_from: replace-with-your-qq-email@qq.com
+  smtp_auth_username: replace-with-your-qq-email@qq.com
+  smtp_auth_password_file: /run/secrets/qq_smtp_auth_code
+  smtp_require_tls: true
+  smtp_force_implicit_tls: true
+
+route:
+  receiver: qq-email-and-sre-webhook
+  group_by:
+    - alertname
+    - job
+    - instance
+  group_wait: 30s
+  group_interval: 5m
+  repeat_interval: 4h
+  routes:
+    - receiver: qq-email-and-sre-webhook
+      matchers:
+        - 'severity = "critical"'
+      repeat_interval: 1h
+
+inhibit_rules:
+  - source_matchers:
+      - 'severity = "critical"'
+    target_matchers:
+      - 'severity = "warning"'
+    equal:
+      - alertname
+      - instance
+
+receivers:
+  - name: qq-email-and-sre-webhook
+    email_configs:
+      - to: replace-with-alert-recipient@qq.com
+        send_resolved: true
+        headers:
+          subject: '[{{ .Status | toUpper }}] Code-Nest {{ .CommonLabels.alertname }}'
+    webhook_configs:
+      - url: http://127.0.0.1:9999/api/internal/sre/alertmanager/v1/alerts
+        send_resolved: true
+        http_config:
+          authorization:
+            type: Bearer
+            credentials_file: /run/secrets/sre_webhook_token

--- a/docker/monitoring/docker-compose.yml
+++ b/docker/monitoring/docker-compose.yml
@@ -2,14 +2,12 @@ services:
   prometheus:
     image: ${PROMETHEUS_IMAGE}
     restart: unless-stopped
-    ports:
-      - "${PROMETHEUS_BIND_ADDRESS}:${PROMETHEUS_PORT}:9090"
-    extra_hosts:
-      - "host.docker.internal:host-gateway"
+    network_mode: host
     command:
       - --config.file=/etc/prometheus/prometheus.yml
       - --storage.tsdb.path=/prometheus
       - --storage.tsdb.retention.time=${PROMETHEUS_RETENTION}
+      - --web.listen-address=${PROMETHEUS_BIND_ADDRESS}:${PROMETHEUS_PORT}
     volumes:
       - ./prometheus.yml:/etc/prometheus/prometheus.yml:ro
       - ./alert_rules.yml:/etc/prometheus/rules/alert_rules.yml:ro
@@ -19,27 +17,26 @@ services:
       - alertmanager
       - node-exporter
       - blackbox-exporter
-    networks:
-      - monitoring
-
   alertmanager:
     image: ${ALERTMANAGER_IMAGE}
     restart: unless-stopped
+    network_mode: host
     command:
       - --config.file=/etc/alertmanager/alertmanager.yml
       - --storage.path=/alertmanager
+      - --web.listen-address=${ALERTMANAGER_BIND_ADDRESS}:${ALERTMANAGER_PORT}
+      - --cluster.listen-address=${ALERTMANAGER_BIND_ADDRESS}:${ALERTMANAGER_CLUSTER_PORT}
     volumes:
       - ./alertmanager/alertmanager.local.yml:/etc/alertmanager/alertmanager.yml:ro
+      # Alertmanager runs as UID 65534. The host secret files must be owned by
+      # that UID with mode 0400; Podman Compose cannot honor Compose secret modes.
       - ./secrets/qq_smtp_auth_code:/run/secrets/qq_smtp_auth_code:ro
+      - ./secrets/sre_webhook_token:/run/secrets/sre_webhook_token:ro
       - alertmanager-data:/alertmanager
-    networks:
-      - monitoring
-
   grafana:
     image: ${GRAFANA_IMAGE}
     restart: unless-stopped
-    ports:
-      - "${GRAFANA_BIND_ADDRESS}:${GRAFANA_PORT}:3000"
+    network_mode: host
     environment:
       GF_SECURITY_ADMIN_USER: ${GRAFANA_ADMIN_USER}
       GF_SECURITY_ADMIN_PASSWORD: ${GRAFANA_ADMIN_PASSWORD}
@@ -47,42 +44,35 @@ services:
       GF_SECURITY_ALLOW_EMBEDDING: "false"
       GF_USERS_ALLOW_SIGN_UP: "false"
       GF_SERVER_ROOT_URL: ${GRAFANA_ROOT_URL}
+      GF_SERVER_HTTP_ADDR: ${GRAFANA_BIND_ADDRESS}
+      GF_SERVER_HTTP_PORT: ${GRAFANA_PORT}
       TZ: Asia/Shanghai
     volumes:
       - grafana-data:/var/lib/grafana
       - ./grafana/provisioning:/etc/grafana/provisioning:ro
     depends_on:
       - prometheus
-    networks:
-      - monitoring
-
   node-exporter:
     image: ${NODE_EXPORTER_IMAGE}
     restart: unless-stopped
+    network_mode: host
     command:
       - --path.rootfs=/host
       - --collector.filesystem.mount-points-exclude=^/(dev|proc|sys|run|var/lib/docker/.+)($$|/)
+      - --web.listen-address=${NODE_EXPORTER_BIND_ADDRESS}:${NODE_EXPORTER_PORT}
     pid: host
     volumes:
       - /:/host:ro,rslave
-    networks:
-      - monitoring
-
   blackbox-exporter:
     image: ${BLACKBOX_EXPORTER_IMAGE}
     restart: unless-stopped
+    network_mode: host
     command:
       - --config.file=/etc/blackbox_exporter/config.yml
+      - --web.listen-address=${BLACKBOX_EXPORTER_BIND_ADDRESS}:${BLACKBOX_EXPORTER_PORT}
     volumes:
       - ./blackbox/config.yml:/etc/blackbox_exporter/config.yml:ro
-    networks:
-      - monitoring
-
 volumes:
   prometheus-data:
   alertmanager-data:
   grafana-data:
-
-networks:
-  monitoring:
-    driver: bridge

--- a/docker/monitoring/grafana/provisioning/datasources/prometheus.yml
+++ b/docker/monitoring/grafana/provisioning/datasources/prometheus.yml
@@ -4,6 +4,6 @@ datasources:
   - name: Prometheus
     type: prometheus
     access: proxy
-    url: http://prometheus:9090
+    url: http://127.0.0.1:19090
     isDefault: true
     editable: false

--- a/docker/monitoring/prometheus.yml
+++ b/docker/monitoring/prometheus.yml
@@ -10,7 +10,7 @@ alerting:
   alertmanagers:
     - static_configs:
         - targets:
-            - alertmanager:9093
+            - 127.0.0.1:19093
 
 rule_files:
   - /etc/prometheus/rules/*.yml
@@ -19,7 +19,7 @@ scrape_configs:
   - job_name: prometheus
     static_configs:
       - targets:
-          - localhost:9090
+          - 127.0.0.1:19090
 
   - job_name: code-nest
     metrics_path: /api/actuator/prometheus
@@ -31,7 +31,7 @@ scrape_configs:
   - job_name: node-exporter
     static_configs:
       - targets:
-          - node-exporter:9100
+          - 127.0.0.1:19100
         labels:
           service: host
 
@@ -51,4 +51,4 @@ scrape_configs:
           - __param_target
         target_label: instance
       - target_label: __address__
-        replacement: blackbox-exporter:9115
+        replacement: 127.0.0.1:19115

--- a/docker/monitoring/scripts/compose.sh
+++ b/docker/monitoring/scripts/compose.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env sh
+set -eu
+
+if command -v docker >/dev/null 2>&1 && docker compose version >/dev/null 2>&1; then
+  exec docker compose "$@"
+fi
+
+if command -v podman >/dev/null 2>&1 && podman compose version >/dev/null 2>&1; then
+  exec podman compose "$@"
+fi
+
+echo "Neither Docker Compose nor Podman Compose is available." >&2
+exit 1

--- a/docker/monitoring/scripts/validate-config.sh
+++ b/docker/monitoring/scripts/validate-config.sh
@@ -7,6 +7,16 @@ ALERTMANAGER_CONFIG="$ROOT_DIR/alertmanager/alertmanager.local.yml"
 CODE_NEST_TARGETS="$ROOT_DIR/targets/code-nest.local.yml"
 BLACKBOX_TARGETS="$ROOT_DIR/targets/blackbox.local.yml"
 SMTP_AUTH_CODE="$ROOT_DIR/secrets/qq_smtp_auth_code"
+SRE_WEBHOOK_TOKEN="$ROOT_DIR/secrets/sre_webhook_token"
+
+if command -v docker >/dev/null 2>&1 && docker compose version >/dev/null 2>&1; then
+  CONTAINER_RUNTIME=docker
+elif command -v podman >/dev/null 2>&1 && podman compose version >/dev/null 2>&1; then
+  CONTAINER_RUNTIME=podman
+else
+  echo "Neither Docker Compose nor Podman Compose is available." >&2
+  exit 1
+fi
 
 if [ ! -f "$ENV_FILE" ]; then
   echo "Missing $ENV_FILE. Copy .env.example first." >&2
@@ -33,22 +43,32 @@ if [ ! -s "$SMTP_AUTH_CODE" ]; then
   exit 1
 fi
 
+if [ ! -f "$SRE_WEBHOOK_TOKEN" ]; then
+  echo "Missing $SRE_WEBHOOK_TOKEN. Create an empty placeholder for the email-only configuration." >&2
+  exit 1
+fi
+
+if grep -q '/run/secrets/sre_webhook_token' "$ALERTMANAGER_CONFIG" && [ ! -s "$SRE_WEBHOOK_TOKEN" ]; then
+  echo "Missing or empty $SRE_WEBHOOK_TOKEN required by the SRE webhook receiver." >&2
+  exit 1
+fi
+
 set -a
 . "$ENV_FILE"
 set +a
 
-docker run --rm --entrypoint /bin/promtool \
+"$CONTAINER_RUNTIME" run --rm --entrypoint /bin/promtool \
   -v "$ROOT_DIR/prometheus.yml:/etc/prometheus/prometheus.yml:ro" \
   -v "$ROOT_DIR/alert_rules.yml:/etc/prometheus/rules/alert_rules.yml:ro" \
   -v "$ROOT_DIR/targets:/etc/prometheus/targets:ro" \
   "$PROMETHEUS_IMAGE" check config /etc/prometheus/prometheus.yml
 
-docker run --rm --entrypoint /bin/promtool \
+"$CONTAINER_RUNTIME" run --rm --entrypoint /bin/promtool \
   -v "$ROOT_DIR/alert_rules.yml:/etc/prometheus/rules/alert_rules.yml:ro" \
   "$PROMETHEUS_IMAGE" check rules /etc/prometheus/rules/alert_rules.yml
 
-docker run --rm --entrypoint /bin/amtool \
+"$CONTAINER_RUNTIME" run --rm --entrypoint /bin/amtool \
   -v "$ALERTMANAGER_CONFIG:/etc/alertmanager/alertmanager.yml:ro" \
   "$ALERTMANAGER_IMAGE" check-config /etc/alertmanager/alertmanager.yml
 
-docker compose --env-file "$ENV_FILE" -f "$ROOT_DIR/docker-compose.yml" config -q
+"$ROOT_DIR/scripts/compose.sh" --env-file "$ENV_FILE" -f "$ROOT_DIR/docker-compose.yml" config -q

--- a/docker/monitoring/targets/code-nest.local.yml.example
+++ b/docker/monitoring/targets/code-nest.local.yml.example
@@ -1,5 +1,5 @@
 - targets:
-    - host.docker.internal:9999
+    - 127.0.0.1:9999
   labels:
     service: code-nest
     environment: production


### PR DESCRIPTION
## Summary

- wire the optional Alertmanager receiver to the authenticated SRE webhook while preserving QQ email delivery
- use Linux host networking with explicit loopback-only ports so monitoring can reach the existing Java service bound to `127.0.0.1:9999`
- avoid the production host's occupied Cockpit port by using Prometheus on `127.0.0.1:19090`
- add a Docker/Podman Compose wrapper and make config validation use the available container runtime
- keep SMTP and webhook credentials outside Git with UID 65534-owned, mode 0400 read-only mounts compatible with the Alertmanager runtime user
- update monitoring runbooks and Draw.io architecture documentation to match the verified deployment topology

## Server Verification

Performed against the production host in isolated temporary Podman projects:

- Prometheus config and all 8 alert rules passed `promtool`
- Alertmanager email plus webhook template passed `amtool check-config`
- Podman Compose configuration passed
- Alertmanager started with both secrets readable as `nobody:nobody 0400`
- all host-network monitoring ports bound only to `127.0.0.1`
- Prometheus confirmed `up == 1` for Code-Nest Actuator, blackbox HTTP probe, node-exporter, and Prometheus itself
- all temporary containers, volumes, and staging directories were removed after verification

## Operational Notes

- this PR does not deploy production or enable the webhook; live activation still requires QQ SMTP credentials, an SRE webhook token, SQL migration, and an application restart with explicit SRE environment flags
- automatic remediation remains disabled