### PR TITLE
fix(release): accept CRLF metadata

### DIFF
--- a/scripts/deploy-release.sh
+++ b/scripts/deploy-release.sh
@@ -418,7 +418,7 @@ restart_service() {
 release_value() {
   local release_file="$1"
   local key="$2"
-  awk -F= -v key="$key" '$1 == key { sub(/^[^=]*=/, ""); print; exit }' "$release_file"
+  awk -F= -v key="$key" '$1 == key { sub(/^[^=]*=/, ""); sub(/\r$/, ""); print; exit }' "$release_file"
 }
 
 load_release_metadata() {

--- a/scripts/deploy-release.test.sh
+++ b/scripts/deploy-release.test.sh
@@ -133,12 +133,12 @@ cp "$monitoring_dir/scripts/compose.sh" "$ops_root/monitoring/scripts/compose.sh
 printf 'new-jar\n' >"$stage/backend/app.jar"
 printf 'new-user\n' >"$stage/user/index.html"
 printf 'new-admin\n' >"$stage/admin/index.html"
-cat >"$stage/RELEASE" <<'EOF'
-version=v2.5.1
-sha=1111111111111111111111111111111111111111
-build_id=release-251-1111111
-built_at=2026-07-28T12:00:00Z
-EOF
+printf '%s\r\n' \
+  'version=v2.5.1' \
+  'sha=1111111111111111111111111111111111111111' \
+  'build_id=release-251-1111111' \
+  'built_at=2026-07-28T12:00:00Z' \
+  >"$stage/RELEASE"
 cp "$deploy_script" "$stage/scripts/deploy-release.sh"
 
 cat >"$stage/scripts/server-capacity-governance.sh" <<'EOF'


### PR DESCRIPTION
## Summary

- normalize trailing CR when parsing release metadata
- cover Windows-generated CRLF RELEASE files in the full deploy/rollback contract

## Production finding

The v2.5.1 bundle was rejected during archive validation before backup or installation because the Windows operator entrypoint emitted CRLF metadata. No production service or active configuration changed.

## Verification

- CRLF contract fails on Linux before the parser fix
- deploy/rollback contract passes on Linux after the fix
- deploy/rollback contract passes in local Git Bash
- shell syntax and git diff checks pass