### PR TITLE
fix(ops): stabilize production baseline

### DIFF
--- a/scripts/verify-production-baseline.sh
+++ b/scripts/verify-production-baseline.sh
@@ -20,6 +20,8 @@ EXPECTED_VERSION="${CODE_NEST_EXPECTED_VERSION:-}"
 EXPECTED_SHA="${CODE_NEST_EXPECTED_SHA:-}"
 MIN_FREE_GB="${CODE_NEST_MIN_FREE_GB:-8}"
 MIN_PROMETHEUS_TARGETS="${CODE_NEST_MIN_PROMETHEUS_TARGETS:-4}"
+PROMETHEUS_TARGET_ATTEMPTS="${CODE_NEST_PROMETHEUS_TARGET_ATTEMPTS:-12}"
+PROMETHEUS_TARGET_INTERVAL_SECONDS="${CODE_NEST_PROMETHEUS_TARGET_INTERVAL_SECONDS:-5}"
 DISK_PATH="${CODE_NEST_DISK_PATH:-$APP_ROOT}"
 RELEASE_FILE="${CODE_NEST_RELEASE_FILE:-$APP_DIR/RELEASE}"
 EXPECTED_SECRET_UID="${CODE_NEST_EXPECTED_SECRET_UID:-65534}"
@@ -100,16 +102,37 @@ check_health() {
 
 check_prometheus_targets() {
   local response
-  if response="$(curl -fsS "$PROMETHEUS_URL/api/v1/targets" 2>/dev/null)" \
-      && jq -e --argjson minimum "$MIN_PROMETHEUS_TARGETS" '
-        .status == "success"
-        and (.data.activeTargets | length) >= $minimum
-        and all(.data.activeTargets[]; .health == "up")
-      ' >/dev/null 2>&1 <<<"$response"; then
-    pass prometheus_targets "minimum=$MIN_PROMETHEUS_TARGETS state=all_up"
-  else
-    fail prometheus_targets "minimum=$MIN_PROMETHEUS_TARGETS url=$PROMETHEUS_URL"
+  local attempt
+
+  if [[ ! "$PROMETHEUS_TARGET_ATTEMPTS" =~ ^[0-9]+$ ]] \
+      || ((PROMETHEUS_TARGET_ATTEMPTS < 1 || PROMETHEUS_TARGET_ATTEMPTS > 30)); then
+    fail prometheus_targets "invalid_attempts=$PROMETHEUS_TARGET_ATTEMPTS"
+    return
   fi
+  if [[ ! "$PROMETHEUS_TARGET_INTERVAL_SECONDS" =~ ^[0-9]+$ ]] \
+      || ((PROMETHEUS_TARGET_INTERVAL_SECONDS > 30)); then
+    fail prometheus_targets "invalid_interval_seconds=$PROMETHEUS_TARGET_INTERVAL_SECONDS"
+    return
+  fi
+
+  for ((attempt = 1; attempt <= PROMETHEUS_TARGET_ATTEMPTS; attempt++)); do
+    if response="$(curl -fsS "$PROMETHEUS_URL/api/v1/targets" 2>/dev/null)" \
+        && jq -e --argjson minimum "$MIN_PROMETHEUS_TARGETS" '
+          .status == "success"
+          and (.data.activeTargets | length) >= $minimum
+          and all(.data.activeTargets[]; .health == "up")
+        ' >/dev/null 2>&1 <<<"$response"; then
+      pass prometheus_targets \
+        "minimum=$MIN_PROMETHEUS_TARGETS state=all_up attempt=$attempt"
+      return
+    fi
+    if ((attempt < PROMETHEUS_TARGET_ATTEMPTS)); then
+      sleep "$PROMETHEUS_TARGET_INTERVAL_SECONDS"
+    fi
+  done
+
+  fail prometheus_targets \
+    "minimum=$MIN_PROMETHEUS_TARGETS attempts=$PROMETHEUS_TARGET_ATTEMPTS url=$PROMETHEUS_URL"
 }
 
 check_grafana() {
@@ -129,7 +152,7 @@ check_grafana() {
 
 release_value() {
   local key="$1"
-  awk -F= -v key="$key" '$1 == key { sub(/^[^=]*=/, ""); print; exit }' "$RELEASE_FILE"
+  awk -F= -v key="$key" '$1 == key { sub(/^[^=]*=/, ""); sub(/\r$/, ""); print; exit }' "$RELEASE_FILE"
 }
 
 check_release() {

--- a/scripts/verify-production-baseline.test.sh
+++ b/scripts/verify-production-baseline.test.sh
@@ -43,7 +43,21 @@ case "$url" in
     printf '{"status":"UP"}'
     ;;
   */api/v1/targets)
-    printf '{"status":"success","data":{"activeTargets":[{"health":"up"},{"health":"up"},{"health":"up"},{"health":"up"}]}}'
+    counter_file="${MOCK_PROMETHEUS_TARGET_COUNTER_FILE:-}"
+    failure_count="${MOCK_PROMETHEUS_TARGET_FAILURES:-0}"
+    attempt=1
+    if [[ -n "$counter_file" ]]; then
+      if [[ -f "$counter_file" ]]; then
+        read -r attempt <"$counter_file"
+        attempt=$((attempt + 1))
+      fi
+      printf '%s\n' "$attempt" >"$counter_file"
+    fi
+    if [[ -n "$counter_file" && "$attempt" -le "$failure_count" ]]; then
+      printf '{"status":"success","data":{"activeTargets":[{"health":"down"},{"health":"up"},{"health":"up"},{"health":"up"}]}}'
+    else
+      printf '{"status":"success","data":{"activeTargets":[{"health":"up"},{"health":"up"},{"health":"up"},{"health":"up"}]}}'
+    fi
     ;;
   */api/health)
     printf '{"database":"ok"}'
@@ -129,11 +143,11 @@ printf 'webhook-secret' >"$monitoring_dir/secrets/sre_webhook_token"
 printf 'GRAFANA_ADMIN_PASSWORD=test-grafana-password\n' >"$monitoring_dir/.env"
 touch "$monitoring_dir/alertmanager/alertmanager.local.yml"
 
-cat >"$app_root/app/RELEASE" <<'EOF'
-version=v2.5.1
-sha=1111111111111111111111111111111111111111
-built_at=2026-07-28T12:00:00Z
-EOF
+printf '%s\r\n' \
+  'version=v2.5.1' \
+  'sha=1111111111111111111111111111111111111111' \
+  'built_at=2026-07-28T12:00:00Z' \
+  >"$app_root/app/RELEASE"
 
 run_baseline() {
   PATH="$mock_bin:$PATH" \
@@ -146,11 +160,23 @@ run_baseline() {
   CODE_NEST_EXPECTED_VERSION="v2.5.1" \
   CODE_NEST_EXPECTED_SHA="1111111111111111111111111111111111111111" \
   CODE_NEST_GRAFANA_REQUIRED="true" \
+  CODE_NEST_PROMETHEUS_TARGET_ATTEMPTS="${CODE_NEST_PROMETHEUS_TARGET_ATTEMPTS:-1}" \
+  CODE_NEST_PROMETHEUS_TARGET_INTERVAL_SECONDS="${CODE_NEST_PROMETHEUS_TARGET_INTERVAL_SECONDS:-0}" \
   bash "$baseline_script"
 }
 
 healthy_output="$(run_baseline)"
 grep -Fq 'PASS check=production_baseline' <<<"$healthy_output"
+
+prometheus_counter="$workspace/prometheus-target-attempts"
+transient_output="$(
+  MOCK_PROMETHEUS_TARGET_COUNTER_FILE="$prometheus_counter" \
+  MOCK_PROMETHEUS_TARGET_FAILURES=2 \
+  CODE_NEST_PROMETHEUS_TARGET_ATTEMPTS=3 \
+  run_baseline
+)"
+grep -Fq 'PASS check=prometheus_targets' <<<"$transient_output"
+[[ "$(cat "$prometheus_counter")" -eq 3 ]]
 
 printf 'drift\n' >>"$monitoring_dir/alert_rules.yml"
 set +e


### PR DESCRIPTION
## Summary

- normalize CRLF release metadata in the production baseline verifier
- poll Prometheus targets with bounded, validated retry settings after monitoring/application restart
- cover two transient down responses followed by recovery in the baseline contract

## Production finding

The v2.5.1 deployment reached the full baseline, then rolled back because the baseline treated CRLF metadata as invalid and checked Prometheus target state before the next scrape. Rollback completed and the previous application is healthy with 4/4 targets up.

## Verification

- transient target test fails before implementation
- production baseline contract passes in local Git Bash
- production baseline contract passes in native Linux under a temporary mock tree
- shell syntax and git diff checks pass